### PR TITLE
ToolchainInfo Schema

### DIFF
--- a/proposals/2018-10-03-toolchaininfo-schema.md
+++ b/proposals/2018-10-03-toolchaininfo-schema.md
@@ -1,0 +1,151 @@
+---
+title: ToolchainInfo Schema
+status: Draft
+created: 2018-10-03
+updated: 2018-10-03
+authors:
+  - [brandjon@](https://github.com/brandjon)
+reviewers:
+  - Starlark core reviewers
+discussion thread: [#????](https://github.com/bazelbuild/starlark/issues/????)
+---
+
+# ToolchainInfo Schema
+
+## Abstract
+
+This doc describes three different ways of structuring data in a `ToolchainInfo` provider. It recommends the third way, which requires an API addition and ideally deprecates the existing way.
+
+## Background
+
+The [toolchain framework](https://docs.bazel.build/versions/master/toolchains.html) takes an abstract dependency of a rule on a toolchain type, and resolves it into a concrete dependency of the rule on a specific tool target implementing that type. For instance, a hypothetical `bar_binary` rule can declare that it needs *some* bar compiler, without saying which one, by requiring `//bar_tools:toolchain_type`. The framework will use platform constraints to translate this into a real dependency on an actual bar compiler such as `//bar_tools:linux_toolchain`.
+
+The concrete toolchain has to pass some information along to the rule that requires it, such as a compiler location, standard library location, and platform-specific flags. For an ordinary dependency this would be done by defining a new provider type for the kind of information being transmitted, e.g. `BarCompilerInfo`, and returning an instance of this provider from the concrete toolchain's rule implementation function. The toolchain framework can't access arbitrary providers of a target, so instead it makes one specific provider available, `ToolchainInfo`, which can encapsulate whatever information the toolchain designer needs to pass along.
+
+```python
+def _bar_toolchain_impl(ctx):
+    # ToolchainInfo is similar to struct(); it holds arbitrary field-value pairs.
+    toolchain_info = ToolchainInfo(
+        compiler_path = ctx.attr.compiler_path,
+        system_lib = ctx.attr.system_lib,
+        arch_flags = ctx.attr.arch_flags,
+    )
+    # Other providers may be returned here but they would only be seen by
+    # targets that directly depend on this one, not targets that find this
+    # one via the toolchain framework.
+    return [toolchain_info]
+
+... # Omitting definition of bar_toolchain rule.
+
+def _bar_binary_impl(ctx):
+    ...
+    # ctx.toolchains returns the ToolchainInfo provider directly (not the Target object).
+    toolchain_info = ctx.toolchains["//bar_tools:toolchain_type"]
+    command = "%s -l %s %s" % (
+        toolchain_info.compiler_path,
+        toolchain_info.system_lib,
+        " ".join(toolchain_info.arch_flags),
+    )
+    ...
+
+... # Omitting definition of bar_binary rule.
+```
+
+It may be debatable whether or not wrapping all toolchain-conveyed information explicitly in a `ToolchainInfo` results in a better user experience for toolchain rule authors and consumers. On the one hand, it's an extra step and introduces a visible difference in the amount of info available via toolchain dependence vs regular dependence. On the other hand, it makes the set of toolchain-visible info more explicit, and is preferred for implementation reasons as well (it avoids proliferating arbitrary inspection of configured targets to list all their providers). Regardless, this doc assumes that `ToolchainInfo` will remain the means of propagating information through the toolchain framework.
+
+Rather, this doc addresses the schema of `ToolchainInfo`. At the moment it is semi-structured, with no guarantee that toolchains return objects with specific fields or values. Any discrepancies will likely lead to an analysis failure dynamically, at the point where an illegal operation is performed, due to a missing field or wrong type of value in a field.
+
+## Option 1: Flat namespace with arbitrary string keys
+
+This is the status quo. It's similar to how you can return legacy-style providers using the `struct` syntax.
+
+```python
+    # _bar_toolchain_impl()
+    ...
+    toolchain_info = ToolchainInfo(
+        compiler_path = "/usr/bin/gcc",
+        compiler_arch_flags = ["--foo"],
+        linker_path = "/usr/bin/ld",
+        linker_arch_flags = ["--bar"],
+    )
+    ...
+
+    # _bar_binary_impl()
+    ...
+    toolchain_info = ctx.toolchains["//bar_tools:toolchain_type"]
+    compiler_path = toolchain_info.compiler_path
+    ...
+```
+
+**Pros:**
+- Straightforward, relatively concise.
+
+**Cons:**
+- Top-level keys share a namespace, so keys from unrelated features might clash. E.g. `compiler_path` and `linker_path` are qualified by the tool because they can't both be `path`.
+- Schema is free-form; toolchain rules and consuming rules must agree on field layout, no eager validation.
+
+## Option 2: One field per provider
+
+This is a convention recommendation: Group values by their logical provider, and return these providers as the top-level fields of the `ToolchainInfo`.
+
+```python
+    # _bar_toolchain_impl()
+    ...
+    toolchain_info = ToolchainInfo(
+        compiler_info = CompilerInfo(
+            path = "/usr/bin/gcc",
+            arch_flags = ["--foo"],
+        ),
+        linker_info = LinkerInfo(
+            path = "/usr/bin/ld",
+            arch_flags = ["--bar"],
+        ),
+    )
+    ...
+
+    # _bar_binary_impl()
+    ...
+    toolchain_info = ctx.toolchains["//bar_tools:toolchain_type"]
+    compiler_path = toolchain_info.compiler_info.path
+    ...
+```
+
+**Pros:**
+- API consistency: adheres to the convention that the atomic unit of information is a provider instance, same as you'd get from depending on the target directly.
+- Helper functions that operate on provider instances will work as-is.
+- Although field names are still loose (though we'd recommend keeping them the same as the provider name), field values are subject to whatever schema requirements the provider type has (allowed fields, their types, their docstrings).
+
+**Cons:**
+- More verbose.
+- User must repeat the provider name as the field name.
+
+# Option 3: Provider-keyed collection
+
+Have `ToolchainInfo` take in a list of provider instances instead of key-value pairs. Provider instances are retrieved from a `ToolchainInfo` object by keying on the provider type. Deprecate and migrate the old struct-like construction and retrievals from `ToolchainInfo`.
+
+```python
+    # _bar_toolchain_impl()
+    ...
+    toolchain_info = ToolchainInfo([
+        CompilerInfo(
+            path = "/usr/bin/gcc",
+            arch_flags = ["--foo"],
+        ),
+        LinkerInfo(
+            path = "/usr/bin/ld",
+            arch_flags = ["--bar"],
+        ),
+    ])
+    ...
+
+    # _bar_binary_impl()
+    ...
+    toolchain_info = ctx.toolchains["//bar_tools:toolchain_type"]
+    compiler_path = toolchain_info[CompilerInfo].path
+    ...
+```
+
+Pros:
+- Analogous to how modern declared/symbolic providers are returned and retrieved for ordinary dependencies.
+- No need to agree on extra field names besides those already covered by a provider's own schema.
+- If toolchain types get the ability to declare advertised/required providers, `ToolchainInfo` objects can be easily validated against these requirements.

--- a/proposals/2018-10-03-toolchaininfo-schema.md
+++ b/proposals/2018-10-03-toolchaininfo-schema.md
@@ -148,7 +148,7 @@ Have `ToolchainInfo` take in a list of provider instances instead of key-value p
 **Pros:**
 - Analogous to how modern declared/symbolic providers are returned and retrieved for ordinary dependencies.
 - No need to agree on extra field names besides those already covered by a provider's own schema.
-- If toolchain types get the ability to declare advertised/required providers, `ToolchainInfo` objects can be easily validated against these requirements.
+- If toolchain types get the ability to declare advertised/required providers, `ToolchainInfo` objects can be easily validated against these requirements. (Related GH issue: [Bazel #6015](https://github.com/bazelbuild/bazel/issues/6015))
 
 **Cons:**
 - Requires a little implementation work.

--- a/proposals/2018-10-03-toolchaininfo-schema.md
+++ b/proposals/2018-10-03-toolchaininfo-schema.md
@@ -119,9 +119,9 @@ This is a convention recommendation: Group values by their logical provider, and
 - More verbose.
 - User must repeat the provider name as the field name.
 
-# Option 3: Provider-keyed collection
+## Option 3: Provider-keyed collection
 
-Have `ToolchainInfo` take in a list of provider instances instead of key-value pairs. Provider instances are retrieved from a `ToolchainInfo` object by keying on the provider type. Deprecate and migrate the old struct-like construction and retrievals from `ToolchainInfo`.
+Have `ToolchainInfo` take in a list of provider instances instead of key-value pairs. Provider instances are retrieved from a `ToolchainInfo` object by keying on the provider type. We'd deprecate the old struct-like construction and retrievals from `ToolchainInfo`.
 
 ```python
     # _bar_toolchain_impl()
@@ -145,7 +145,16 @@ Have `ToolchainInfo` take in a list of provider instances instead of key-value p
     ...
 ```
 
-Pros:
+**Pros:**
 - Analogous to how modern declared/symbolic providers are returned and retrieved for ordinary dependencies.
 - No need to agree on extra field names besides those already covered by a provider's own schema.
 - If toolchain types get the ability to declare advertised/required providers, `ToolchainInfo` objects can be easily validated against these requirements.
+
+**Cons:**
+- Requires a little implementation work.
+
+## Backward compatibility
+
+To deprecate struct-style construction and access for `ToolchainInfo`, we'd just need an `--incompatible_*` flag that disables passing keyword arguments to `ToolchainInfo`. Without the ability to construct legacy `ToolchainInfo` objects, all field retrievals on `ToolchainInfo` would also become invalid (no-such-field errors). The flag would also intercept and disallow `to_json` and `to_proto` if needed.
+
+When the flag is not enabled, both the legacy and provider-keyed styles would be permitted on the same `ToolchainInfo` object, to assist with migration.

--- a/proposals/2018-10-03-toolchaininfo-schema.md
+++ b/proposals/2018-10-03-toolchaininfo-schema.md
@@ -7,7 +7,7 @@ authors:
   - [brandjon@](https://github.com/brandjon)
 reviewers:
   - Starlark core reviewers
-discussion thread: [#????](https://github.com/bazelbuild/starlark/issues/????)
+discussion thread: [#12](https://github.com/bazelbuild/starlark/issues/12)
 ---
 
 # ToolchainInfo Schema

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -7,3 +7,4 @@ proposal, see the [design process](../process.md).
 Last updated | Status | Title | Author(s) | Category
 ------------ | ------ | ------| ----------| --------
 2018-08-17   | Draft  | [Genrule setup for Starlark](https://github.com/bazelbuild/starlark/blob/master/proposals/2018-08-17-genrule-setup-for-starlark.md) | [brandjon@](https://github.com/brandjon) | Actions
+2018-10-03   | Draft  | [ToolchainInfo Schema](https://github.com/bazelbuild/starlark/blob/master/proposals/2018-10-03-toolchaininfo-schema.md) | [brandjon@](https://github.com/brandjon) | Toolchains


### PR DESCRIPTION
This is a proposal to make `ToolchainInfo` resemble `Target` objects, by having its constructor take a sequence of provider instances, and retrieving provider instances by keying on the provider type.

I do not intend to implement this in the near future, but I suspect the design may be non-controversial.