### PR TITLE
Fix specification for string.capitalize()

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2766,11 +2766,11 @@ x.remove(2)                             # error: element not found
 <a id='string·capitalize'></a>
 ### string·capitalize
 
-`S.capitalize()` returns a copy of string S with all Unicode letters
-that begin words changed to their title case.
+`S.capitalize()` returns a copy of string S, where the first character (if any)
+is converted to uppercase; all other characters are converted to lowercase.
 
 ```python
-"hello, world!".capitalize()		# "Hello, World!"
+"hello, world!".capitalize()		# "Hello, world!"
 ```
 
 <a id='string·count'></a>


### PR DESCRIPTION
This was a mistake, as discussed on https://github.com/google/skylark/issues/140

string.capitalize uses uppercase only for the first character, unlike
string.title which does it for the first character of every word.