### PR TITLE
Remove expected error msgs from code before executing it

### DIFF
--- a/test_suite/starlark_test.py
+++ b/test_suite/starlark_test.py
@@ -24,10 +24,12 @@ class StarlarkTest(unittest.TestCase):
           expected_errors = []
           code = []
         else:
-          code.append(line)
           i = line.find(self.ERR_SEP)
           if i >= 0:
             expected_errors.append(line[i + len(self.ERR_SEP):].strip())
+            code.append(line[:i])
+          else:
+            code.append(line)
     yield code, expected_errors
 
   def evaluate(self, f):
@@ -52,7 +54,7 @@ class StarlarkTest(unittest.TestCase):
       # Try both substring and regex matching.
       if exp not in output_ and not re.search(exp, output_):
         self.seen_error = True
-        print("Error `{}` not found, got: `{}`".format(exp, output))
+        print("Error `{}` not found, got: `{}`".format(exp.encode('utf-8'), output.encode('utf-8')))
 
   PRELUDE = """
 def assert_eq(x, y):

--- a/test_suite/testdata/java/int.star
+++ b/test_suite/testdata/java/int.star
@@ -63,4 +63,4 @@ compound()
 ---
 1 // 0  ### division by zero
 ---
-1 % 0  ### integer modulo by zero
+1 % 0  ### (integer modulo by zero|division by zero)

--- a/test_suite/testdata/java/int_constructor.star
+++ b/test_suite/testdata/java/int_constructor.star
@@ -19,15 +19,15 @@ assert_eq(int('0XFF', 0), 255)
 assert_eq(int('0xFF', 16), 255)
 
 ---
-int('1.5') ### invalid literal
+int('1.5') ### (invalid literal|not a base 10)
 ---
-int('ab') ### invalid literal
+int('ab') ### (invalid literal|not a base 10)
 ---
 int(None) ### None
 ---
-int('123', 3) ### invalid literal
+int('123', 3) ### (invalid literal|not a base 3)
 ---
-int('FF', 15) ### invalid literal
+int('FF', 15) ### (invalid literal|not a base 15)
 ---
 int('123', -1) ### >= 2 (and|&&) <= 36
 ---
@@ -35,10 +35,10 @@ int('123', 1) ### >= 2 (and|&&) <= 36
 ---
 int('123', 37) ### >= 2 (and|&&) <= 36
 ---
-int('0xFF', 8) ### invalid literal
+int('0xFF', 8) ### (invalid literal|not a base 8)
 ---
-int(True, 2) ### can't convert non-string with explicit base
+int(True, 2) ### (can't convert non-string with explicit base|non-string)
 ---
-int(1, 2) ### can't convert non-string with explicit base
+int(1, 2) ### (can't convert non-string with explicit base|non-string)
 ---
-int(True, 10) ### can't convert non-string with explicit base
+int(True, 10) ### (can't convert non-string with explicit base|non-string)

--- a/test_suite/testdata/java/int_function.star
+++ b/test_suite/testdata/java/int_function.star
@@ -13,7 +13,7 @@ assert_eq(int(False), 0)
 int(None) ### None
 ---
 # This case is allowed in Python but not Skylark
-int() ### x
+int() ### (no default value|not enough parameters|missing argument)
 ---
 
 # string, no base
@@ -34,18 +34,18 @@ assert_eq(int('+42'), 42)
 ---
 # int(-2147483649) ## invalid base-10 integer constant: 2147483649
 ---
-int('') ### (cannot be empty|invalid literal)
+int('') ### (cannot be empty|invalid literal|not a base 10)
 ---
 # Surrounding whitespace is not allowed
-int('  42  ') ### invalid literal
+int('  42  ') ### (invalid literal|not a base 10)
 ---
-int('-') ### invalid literal
+int('-') ### (invalid literal|not a base 10)
 ---
-int('0x') ### invalid literal
+int('0x') ### (invalid literal|not a base 16)
 ---
-int('1.5') ### invalid literal
+int('1.5') ### (invalid literal|not a base 10)
 ---
-int('ab') ### invalid literal
+int('ab') ### (invalid literal|not a base 10)
 ---
 
 assert_eq(int('11', 2), 3)
@@ -64,9 +64,9 @@ assert_eq(int('016', 16), 22)
 # invalid base
 # int('016', 0) ## base.*016
 ---
-int('123', 3) ### invalid literal
+int('123', 3) ### (invalid literal|not a base 3)
 ---
-int('FF', 15) ### invalid literal
+int('FF', 15) ### (invalid literal|not a base 15)
 ---
 int('123', -1) ### >= 2 (and|&&) <= 36
 ---
@@ -74,7 +74,7 @@ int('123', 1) ### >= 2 (and|&&) <= 36
 ---
 int('123', 37) ### >= 2 (and|&&) <= 36
 ---
-int('123', 'x') ### base must be an integer
+int('123', 'x') ### (base must be an integer|not supported)
 ---
 
 # base with prefix
@@ -88,10 +88,10 @@ assert_eq(int('0XFF', 0), 255)
 assert_eq(int('0xFF', 16), 255)
 
 ---
-int('0xFF', 8) ### invalid literal
+int('0xFF', 8) ### (invalid literal|not a base 8)
 ---
-int(True, 2) ### can't convert non-string with explicit base
+int(True, 2) ### (can't convert non-string with explicit base|non-string)
 ---
-int(1, 2) ### can't convert non-string with explicit base
+int(1, 2) ### (can't convert non-string with explicit base|non-string)
 ---
-int(True, 10) ### can't convert non-string with explicit base
+int(True, 10) ### (can't convert non-string with explicit base|non-string)

--- a/test_suite/testdata/java/list_mutation.star
+++ b/test_suite/testdata/java/list_mutation.star
@@ -18,7 +18,7 @@ foo.insert(10, 'g')
 assert_eq(foo, ['f', 'c', 'd', 'a', 'b', 'e', 'g'])
 
 ---
-(1, 2).insert(3) ### no (method insert|\.insert field)
+(1, 2).insert(3) ### (no (method insert|\.insert field)|not supported)
 ---
 
 # append
@@ -30,7 +30,7 @@ foo.append('d')
 assert_eq(foo, ['a', 'b', 'c', 'd'])
 
 ---
-(1, 2).append(3) ### no (method append|\.append field)
+(1, 2).append(3) ### (no (method append|\.append field)|not supported)
 ---
 
 # extend
@@ -41,9 +41,9 @@ foo.extend(('e', 'f'))
 assert_eq(foo, ['a', 'b', 'c', 'd', 'e', 'f'])
 
 ---
-(1, 2).extend([3, 4]) ### no (method extend|\.extend field)
+(1, 2).extend([3, 4]) ### (no (method extend|\.extend field)|not supported)
 ---
-[1, 2].extend(3) ### (expected value of type|got int, want iterable)
+[1, 2].extend(3) ### (expected value of type|got int, want iterable|not iterable)
 
 # remove
 
@@ -62,7 +62,7 @@ foo.remove('b')
 assert_eq(foo, [])
 
 ---
-(1, 2).remove(3) ### no (method remove|\.remove field)
+(1, 2).remove(3) ### (no (method remove|\.remove field)|not supported)
 ---
 [1, 2].remove(3) ### not found
 ---
@@ -85,6 +85,6 @@ assert_eq(li3.pop(1), 3)
 assert_eq(li3, [2, 4])
 
 ---
-[1, 2].pop(3) ### index( 3)? out of range
+[1, 2].pop(3) ### (out of range|out of bound)
 ---
-(1, 2).pop() ### no (method pop|\.pop field)
+(1, 2).pop() ### (no (method pop|\.pop field)|not supported)

--- a/test_suite/testdata/java/list_slices.star
+++ b/test_suite/testdata/java/list_slices.star
@@ -57,28 +57,28 @@ assert_eq([0, 1, 2][-1], 2)
 assert_eq([0, 1, 2][0], 0)
 
 ---
-'123'['a'::] ### (slice start must be an integer, not 'a'|invalid start index)
+'123'['a'::] ### (slice start must be an integer, not 'a'|invalid start index|parameters mismatch)
 ---
-'123'[:'b':] ### (slice end must be an integer, not 'b'|invalid end index)
+'123'[:'b':] ### (slice end must be an integer, not 'b'|invalid end index|parameters mismatch)
 ---
-(1, 2, 3)[1::0] ### (slice step cannot be zero|zero is not a valid slice step)
+(1, 2, 3)[1::0] ### (slice step cannot be zero|zero is not a valid slice step|out of bound)
 ---
-[1, 2, 3][::0] ### (slice step cannot be zero|zero is not a valid slice step)
+[1, 2, 3][::0] ### (slice step cannot be zero|zero is not a valid slice step|out of bound)
 ---
-[1, 2, 3][1::0] ### (slice step cannot be zero|zero is not a valid slice step)
+[1, 2, 3][1::0] ### (slice step cannot be zero|zero is not a valid slice step|out of bound)
 ---
-[1, 2, 3][:3:0] ### (slice step cannot be zero|zero is not a valid slice step)
+[1, 2, 3][:3:0] ### (slice step cannot be zero|zero is not a valid slice step|out of bound)
 ---
-[1, 2, 3][1:3:0] ### (slice step cannot be zero|zero is not a valid slice step)
+[1, 2, 3][1:3:0] ### (slice step cannot be zero|zero is not a valid slice step|out of bound)
 ---
-[[1], [2]]['a'] ### (indices must be integers, not string|got string, want int)
+[[1], [2]]['a'] ### (indices must be integers, not string|got string, want int|parameters mismatch)
 ---
-[0, 1, 2][3] ### index( 3)? out of range
+[0, 1, 2][3] ### (out of range|out of bound)
 ---
-[0, 1, 2][-4] ### index( -4)? out of range
+[0, 1, 2][-4] ### (out of range|out of bound)
 ---
-[0][-2] ### index( -2)? out of range
+[0][-2] ### (out of range|out of bound)
 ---
-[0][1] ### index( 1)? out of range
+[0][1] ### (out of range|out of bound)
 ---
-[][1] ### index( 1)? out of range
+[][1] ### (out of range|out of bound)

--- a/test_suite/testdata/java/min_max.star
+++ b/test_suite/testdata/java/min_max.star
@@ -35,9 +35,9 @@ assert_eq(max([1, 1, 1, 1, 1, 1]), 1)
 ---
 min(1)  ### not iterable
 ---
-min([])  ### (expected at least one item|empty sequence)
+min([])  ### (expected at least one item|empty)
 ---
-max([]) ### (expected at least one item|empty sequence)
+max([]) ### (expected at least one item|empty)
 ---
 max(1) ### not iterable
 ---

--- a/test_suite/testdata/java/reversed.star
+++ b/test_suite/testdata/java/reversed.star
@@ -9,9 +9,9 @@ assert_eq(reversed([]), [])
 # assert_eq(reversed('bbb'.elems()), ['b', 'b', 'b'])
 
 ---
-reversed(None) ### (parameter 'sequence' cannot be None|got NoneType, want iterable)
+reversed(None) ### (parameter 'sequence' cannot be None|got NoneType, want iterable|not iterable)
 ---
-reversed(1) ### (type 'int' is not iterable|got int, want iterable)
+reversed(1) ### (type 'int' is not iterable|got int, want iterable|not iterable)
 ---
 # _inconsistency_: go, rust reversed() accepts dict as argument
 # reversed({1: 3}) ## Argument to reversed() must be a sequence, not a dictionary

--- a/test_suite/testdata/java/string_format.star
+++ b/test_suite/testdata/java/string_format.star
@@ -54,15 +54,15 @@ assert_eq('{test} and {}'.format(2, test = 1), "1 and 2")
 assert_eq('{test} and {0}'.format(2, test = 1), "1 and 2")
 
 ---
-'{{}'.format(1) ### (Found '}' without matching '{'|single '}')
+'{{}'.format(1) ### (Found '}' without matching '{'|single '}'|standalone '}')
 ---
-'{}}'.format(1) ### (Found '}' without matching '{'|single '}')
+'{}}'.format(1) ### (Found '}' without matching '{'|single '}'|standalone '}')
 ---
-'{0}'.format() ### (No replacement found for index 0|index out of range)
+'{0}'.format() ### (No replacement found for index 0|index out of range|out of bound)
 ---
-'{0} and {1}'.format('this') ### (No replacement found for index 1|index out of range)
+'{0} and {1}'.format('this') ### (No replacement found for index 1|index out of range|out of bound)
 ---
-'{0} and {2}'.format('this', 'that') ### (No replacement found for index 2|index out of range)
+'{0} and {2}'.format('this', 'that') ### (No replacement found for index 2|index out of range|out of bound)
 ---
 # _inconsistency_: -0 not allowed in go,rust, different error
 # '{-0} and {-1}'.format('this', 'that') ##
@@ -71,9 +71,9 @@ assert_eq('{test} and {0}'.format(2, test = 1), "1 and 2")
 ---
 '{0.1} and {1}'.format('this', 'that') ### (Invalid character '.' inside replacement field|not supported)
 ---
-'{}'.format() ### (No replacement found for index 0|index out of range)
+'{}'.format() ### (No replacement found for index 0|index out of range|not enough parameters)
 ---
-'{} and {}'.format('this') ### (No replacement found for index 1|index out of range)
+'{} and {}'.format('this') ### (No replacement found for index 1|index out of range|not enough parameters)
 ---
 '{test} and {}'.format(test = 1, 2) ### positional argument
 ---
@@ -89,6 +89,6 @@ assert_eq('{test} and {0}'.format(2, test = 1), "1 and 2")
 ---
 '{test,}'.format(test = 1) ### (Invalid character ',' inside replacement field|not found)
 ---
-'{ {} }'.format(42) ### Nested replacement fields
+'{ {} }'.format(42) ### (Nested replacement fields|unmatched '{')
 ---
-'{a}{b}'.format(a = 5) ### (Missing argument 'b'|keyword b not found)
+'{a}{b}'.format(a = 5) ### (Missing argument 'b'|not found)

--- a/test_suite/testdata/java/string_misc.star
+++ b/test_suite/testdata/java/string_misc.star
@@ -2,7 +2,7 @@
 assert_eq('-'.join(['a', 'b', 'c']), "a-b-c")
 
 ---
-join(' ', ['a', 'b', 'c']) ### (name 'join' is not defined|undefined)
+join(' ', ['a', 'b', 'c']) ### (name 'join' is not defined|undefined|not found)
 ---
 
 assert_eq(''.join([(x + '*') for x in ['a', 'b', 'c']]), "a*b*c*")
@@ -80,11 +80,11 @@ assert_eq('Apricot'.endswith('co'), False)
 # assert_eq('a'.endswith(()), False)
 # assert_eq(''.endswith(()), False)
 ---
-'a'.endswith(['a']) ### (expected value of type 'string or tuple of strings'|got list)
+'a'.endswith(['a']) ### (expected value of type 'string or tuple of strings'|got list|parameters mismatch)
 ---
-'1'.endswith((1,)) ### (got type 'int'|got int)
+'1'.endswith((1,)) ### (got type 'int'|got int|parameters mismatch)
 ---
-'a'.endswith(('1', 1)) ### (got type 'int'|got int)
+'a'.endswith(('1', 1)) ### (got type 'int'|got int|parameters mismatch)
 ---
 
 # startswith
@@ -110,11 +110,11 @@ assert_eq(''.startswith('a'), False)
 # assert_eq('a'.startswith(()), False)
 # assert_eq(''.startswith(()), False)
 ---
-'a'.startswith(['a']) ### (expected value of type 'string or tuple of strings'|got list)
+'a'.startswith(['a']) ### (expected value of type 'string or tuple of strings'|got list|expected string)
 ---
-'1'.startswith((1,)) ### (got type 'int'|got int)
+'1'.startswith((1,)) ### (got type 'int'|got int|expected string)
 ---
-'a'.startswith(('1', 1)) ### (got type 'int'|got int)
+'a'.startswith(('1', 1)) ### (got type 'int'|got int|expected string)
 ---
 
 # substring

--- a/test_suite/testdata/java/string_slice_index.star
+++ b/test_suite/testdata/java/string_slice_index.star
@@ -8,9 +8,9 @@ assert_eq('somestring'[-2], "n")
 assert_eq('somestring'[-10], "s")
 
 ---
-'abcdef'[10] ### out of range
+'abcdef'[10] ### (out of range|out of bound)
 ---
-'abcdef'[-11] ### out of range
+'abcdef'[-11] ### (out of range|out of bound)
 ---
 
 # slicing
@@ -46,15 +46,15 @@ assert_eq('123'[3:1:1], "")
 assert_eq('123'[1:3:-1], "")
 
 ---
-'123'[::0] ### (slice step cannot be zero|not a valid slice step)
+'123'[::0] ### (slice step cannot be zero|not a valid slice step|out of bound)
 ---
-'123'[1::0] ### (slice step cannot be zero|not a valid slice step)
+'123'[1::0] ### (slice step cannot be zero|not a valid slice step|out of bound)
 ---
-'123'[:3:0] ### (slice step cannot be zero|not a valid slice step)
+'123'[:3:0] ### (slice step cannot be zero|not a valid slice step|out of bound)
 ---
-'123'[1:3:0] ### (slice step cannot be zero|not a valid slice step)
+'123'[1:3:0] ### (slice step cannot be zero|not a valid slice step|out of bound)
 ---
-'123'['a'::] ### (slice start must be an integer, not 'a'|want int)
+'123'['a'::] ### (slice start must be an integer, not 'a'|want int|parameters mismatch)
 ---
-'123'[:'b':] ### (slice end must be an integer, not 'b'|want int)
+'123'[:'b':] ### (slice end must be an integer, not 'b'|want int|parameters mismatch)
 ---


### PR DESCRIPTION
Remove error msgs from code before executing it and fix some test cases by adding Rust's error msgs.

When an error occurs in the Rust implementation, the source line is included in the error message.
Since we used regex to search for the error msg after `###`, many errors were masked because `### <error>` was already included as part of the source line in the error msg.