### PR TITLE
Remove `not` from binary operators in the spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1298,7 +1298,6 @@ Starlark has the following binary operators, arranged in order of increasing pre
 ```text
 or
 and
-not
 ==   !=   <   >   <=   >=   in   not in
 -   +
 *   /   //   %
@@ -1313,7 +1312,6 @@ BinaryExpr = Test {Binop Test} .
 
 Binop = 'or'
       | 'and'
-      | 'not'
       | '==' | '!=' | '<' | '>' | '<=' | '>=' | 'in' | 'not' 'in'
       | '-' | '+'
       | '*' | '%' | '/' | '//'


### PR DESCRIPTION
`not` is not a binary operator and shouldn't be mentioned in their precedence order.