### PR TITLE
Load Python rules from @rules_python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all bazel-* symlinks. There is no full list since this can change
+# based on the name of the directory bazel is cloned into.
+/bazel-*
+# Bazelisk version file
+.bazelversion

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,15 @@ http_archive(
     ],
 )
 
+git_repository(
+    name = "rules_python",
+    remote = "https://github.com/bazelbuild/rules_python.git",
+    commit = "4b84ad270387a7c439ebdccfd530e2339601ef27",  # 2019-08-02
+)
+
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()
+
 http_archive(
     name = "rules_proto",
     sha256 = "88b0a90433866b44bb4450d4c30bc5738b8c4f9c9ba14e9661deb123f56a833d",

--- a/test_suite/BUILD
+++ b/test_suite/BUILD
@@ -1,3 +1,5 @@
+load("@rules_python//python:defs.bzl", "py_test")
+
 [
     [
         py_test(


### PR DESCRIPTION
This ensures compatibility with bazelbuild/bazel#9006.

Also add a basic .gitignore.

FYI this addresses the specific issue that caused the breakage #78 worked around.