### PR TITLE
Do not generate tests from .*.swp

### DIFF
--- a/test_suite/BUILD
+++ b/test_suite/BUILD
@@ -18,7 +18,9 @@ load("@rules_python//python:defs.bzl", "py_test")
             ],
             main = "starlark_test.py",
         )
-        for test_file in glob(["testdata/java/*", "testdata/go/*", "testdata/rust/*"])
+        for test_file in glob([
+            "testdata/java/*", "testdata/go/*", "testdata/rust/*"
+        ], exclude = ["**/.*"])
     ]
     for impl, binary_rule in [("java", "@io_bazel//src/main/java/com/google/devtools/starlark:Starlark"),
                               ("go", "@net_starlark_go//cmd/starlark:starlark"),


### PR DESCRIPTION
Do not generate tests from temporary vi files.

```
bazel query //test_suite/...
```

```
--- /Users/me/11	2020-07-23 23:08:07.000000000 +0100
+++ /Users/me/22	2020-07-23 23:08:11.000000000 +0100
@@ -5,7 +5,6 @@
 //test_suite:starlark_rust_test_testdata/rust/int_star
 //test_suite:starlark_rust_test_testdata/rust/dict_star
 //test_suite:starlark_rust_test_testdata/rust/bool_star
-//test_suite:starlark_rust_test_testdata/rust/_mutation_during_iteration_star_swp
 //test_suite:starlark_rust_test_testdata/java/string_test_characters_star
 //test_suite:starlark_rust_test_testdata/java/string_splitlines_star
 //test_suite:starlark_rust_test_testdata/java/string_split_star
@@ -45,7 +44,6 @@
 //test_suite:starlark_java_test_testdata/rust/int_star
 //test_suite:starlark_java_test_testdata/rust/dict_star
 //test_suite:starlark_java_test_testdata/rust/bool_star
-//test_suite:starlark_java_test_testdata/rust/_mutation_during_iteration_star_swp
 //test_suite:starlark_java_test_testdata/java/string_test_characters_star
 //test_suite:starlark_java_test_testdata/java/string_splitlines_star
 //test_suite:starlark_java_test_testdata/java/string_split_star
@@ -85,7 +83,6 @@
 //test_suite:starlark_go_test_testdata/rust/int_star
 //test_suite:starlark_go_test_testdata/rust/dict_star
 //test_suite:starlark_go_test_testdata/rust/bool_star
-//test_suite:starlark_go_test_testdata/rust/_mutation_during_iteration_star_swp
 //test_suite:starlark_go_test_testdata/java/string_test_characters_star
 //test_suite:starlark_go_test_testdata/java/string_splitlines_star
 //test_suite:starlark_go_test_testdata/java/string_split_star
```