### PR TITLE
Better diagnostics in starlark-test

### DIFF
--- a/test_suite/starlark_test.py
+++ b/test_suite/starlark_test.py
@@ -16,13 +16,19 @@ class StarlarkTest(unittest.TestCase):
   def chunks(self, path):
     code = []
     expected_errors = []
+    # Current line no
+    line_no = 0
+    # Current test first line no
+    test_line_no = 1
     with open(path, mode="rb") as f:
       for line in f:
+        line_no += 1
         line = line.decode("utf-8")
         if line.strip() == self.CHUNK_SEP:
-          yield code, expected_errors
+          yield code, expected_errors, test_line_no
           expected_errors = []
           code = []
+          test_line_no = line_no + 1
         else:
           i = line.find(self.ERR_SEP)
           if i >= 0:
@@ -30,7 +36,7 @@ class StarlarkTest(unittest.TestCase):
             code.append(line[:i])
           else:
             code.append(line)
-    yield code, expected_errors
+    yield code, expected_errors, test_line_no
 
   def evaluate(self, f):
     """Execute Starlark file, return stderr."""
@@ -39,14 +45,14 @@ class StarlarkTest(unittest.TestCase):
     _, stderr = proc.communicate()
     return stderr
 
-  def check_output(self, output, expected):
+  def check_output(self, output, expected, line_no):
     if expected and not output:
       self.seen_error = True
-      print("Expected error:", expected)
+      print("Test L{}: expected error: {}".format(line_no, expected))
 
     if output and not expected:
       self.seen_error = True
-      print("Unexpected error:", output)
+      print("Test L{}: unexpected error: {}".format(line_no, output))
 
     output_ = output.lower()
     for exp in expected:
@@ -54,7 +60,8 @@ class StarlarkTest(unittest.TestCase):
       # Try both substring and regex matching.
       if exp not in output_ and not re.search(exp, output_):
         self.seen_error = True
-        print("Error `{}` not found, got: `{}`".format(exp.encode('utf-8'), output.encode('utf-8')))
+        print("Test L{}: error not found: `{}`".format(line_no, exp.encode('utf-8')))
+        print("Got: `{}`".format(output.encode('utf-8')))
 
   PRELUDE = """
 def assert_eq(x, y):
@@ -71,9 +78,9 @@ def assert_(cond, msg="assertion failed"):
 """
 
   def testFile(self):
-    print("===", test_file, "===")
+    print("=== {} with {} ===".format(test_file, impl))
     f = os.path.join(testenv.STARLARK_TESTDATA_PATH, test_file)
-    for chunk, expected in self.chunks(f):
+    for chunk, expected, line_no in self.chunks(f):
       with tempfile.NamedTemporaryFile(
           mode="wb", suffix=".star", delete=False) as tmp:
         lines = [line.encode("utf-8") for line in
@@ -81,13 +88,14 @@ def assert_(cond, msg="assertion failed"):
         tmp.writelines(lines)
       output = self.evaluate(tmp.name).decode("utf-8")
       os.unlink(tmp.name)
-      self.check_output(output, expected)
+      self.check_output(output, expected, line_no)
     if self.seen_error:
       raise Exception("Test failed")
     pass
 
 if __name__ == "__main__":
   # Test filename is the last argument on the command-line.
+  impl = sys.argv[-2]
   test_file = sys.argv[-1]
-  binary_path = glob.glob(testenv.STARLARK_BINARY_PATH[sys.argv[-2]])[0]
+  binary_path = glob.glob(testenv.STARLARK_BINARY_PATH[impl])[0]
   unittest.main(argv=sys.argv[2:])


### PR DESCRIPTION
* print which implementation was used in test log
* pritn line number of the test
* split output mismatch into two lines

Otherwise fixing existing tests on impl upgrade is quite hard.