### PR TITLE
spec: duplicate keyword args f(x=1, x=2) is a static error

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -942,6 +942,11 @@ Once the parameters have been successfully bound to the arguments
 supplied by the call, the sequence of statements that comprise the
 function body is executed.
 
+It is a static error if a function call has two named arguments of the
+same name, such as `f(x=1, x=2)`. A call that provides a `**kwargs`
+argument may yet have two values for the same name, such as
+`f(x=1, **dict(x=2))`. This results in a dynamic error.
+
 Function arguments are evaluated in the order they appear in the call.
 <!-- see https://github.com/bazelbuild/starlark/issues/13 -->
 


### PR DESCRIPTION
This wording comes from https://github.com/google/starlark-go/commit/2c65f9e0f5e155edb22bcf767d709321069553e9

Fixes #21
