### PR TITLE
Spec: fix dict.setdefault example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3196,10 +3196,12 @@ present; `setdefault` additionally inserts the new key/value entry into the dict
 ```python
 x = {"one": 1, "two": 2}
 x.setdefault("one")                     # 1
-x.setdefault("three", 0)                # 0
-x                                       # {"one": 1, "two": 2, "three": 0}
+x.setdefault("three", 3)                # 3
+x                                       # {"one": 1, "two": 2, "three": 3}
+x.setdefault("three", 33)               # 3
+x                                       # {"one": 1, "two": 2, "three": 3}
 x.setdefault("four")                    # None
-x                                       # {"one": 1, "two": 2, "three": None}
+x                                       # {"one": 1, "two": 2, "three": 3, "four": None}
 ```
 
 <a id='dict·update'></a>


### PR DESCRIPTION
* `setdefault` sets `None` when there's no key and `default` is not given
* add an example where `setdefault` is called with existing key