### PR TITLE
Spec: fix string.join example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3559,7 +3559,7 @@ are strings.
 
 ```python
 ", ".join(["one", "two", "three"])      # "one, two, three"
-"a".join("ctmrn")                       # "catamaran"
+"a".join("ctmrn".elems())               # "catamaran"
 ```
 
 <a id='string·lower'></a>


### PR DESCRIPTION
string is not iterable, thus it cannot be used as an argument to
`string.join`.