### PR TITLE
Fix CI

### DIFF
--- a/test_suite/testdata/rust/josharian_fuzzing.star
+++ b/test_suite/testdata/rust/josharian_fuzzing.star
@@ -25,4 +25,6 @@ assert_eq(0in[1,2,3], False)
 assert_eq(dir(""), sorted(dir("")))
 ---
 # https://github.com/google/starlark-rust/issues/66: / is only for floats (which we don't support)
-1 / 1  ### (not supported|does not support|not allowed)
+### rust: not supported
+### java: operator is not allowed
+1 / 1


### PR DESCRIPTION
... and also allow different expected output for different implementations.

New syntax is:

```
 ### java: this is error in java
 ### go: go will fail here
 # rust won't fail it
```