### PR TITLE
Unbreak buildkite

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -90,7 +90,7 @@ genrule(
     name = "starlark",
     outs = ["target/debug/starlark-repl"],
     srcs = ["."],
-    cmd = "cd $(SRCS) && cargo build && cd - && cp $(SRCS)/target/debug/starlark-rust $@",
+    cmd = "cd $(SRCS) && cargo build && cd - && cp $(SRCS)/target/debug/starlark $@",
     executable = True,
     local = True,
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,7 +83,7 @@ go_repository(
 # Assumes you have cargo/rust installed
 new_git_repository(
   name = "starlark-rust",
-  remote = "https://github.com/google/starlark-rust.git",
+  remote = "https://github.com/facebookexperimental/starlark-rust.git",
   branch = "master",
   build_file_content = """
 genrule(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,18 +51,24 @@ git_repository(
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz"],
-    sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
+    sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
+    ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
-    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+    ],
 )
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()
-go_register_toolchains()
+go_register_toolchains(version = "1.16.5")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 gazelle_dependencies()
 load("@bazel_gazelle//:deps.bzl", "go_repository")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,7 +46,7 @@ rules_pkg_dependencies()
 git_repository(
     name = "io_bazel",
     remote = "https://github.com/bazelbuild/bazel.git",
-    commit = "72013afdeae42dc55a566e532574d310f34af729", # 2020-07-23
+    commit = "69a2f92c7a98e25f70c90a84742d12ea46c7a3b4", # 2021-07-09
 )
 
 http_archive(

--- a/test_suite/BUILD
+++ b/test_suite/BUILD
@@ -22,7 +22,7 @@ load("@rules_python//python:defs.bzl", "py_test")
             "testdata/java/*", "testdata/go/*", "testdata/rust/*"
         ], exclude = ["**/.*"])
     ]
-    for impl, binary_rule in [("java", "@io_bazel//src/main/java/net/starlark/java/cmd:Starlark"),
+    for impl, binary_rule in [("java", "@io_bazel//src/main/java/net/starlark/java/cmd:starlark"),
                               ("go", "@net_starlark_go//cmd/starlark:starlark"),
                               ("rust", "@starlark-rust//:starlark")]
 ]

--- a/test_suite/starlark_test.py
+++ b/test_suite/starlark_test.py
@@ -43,8 +43,11 @@ class StarlarkTest(unittest.TestCase):
     """Execute Starlark file, return stderr."""
     proc = subprocess.Popen(
         [binary_path, f], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
-    _, stderr = proc.communicate()
-    return stderr
+    stdout, stderr = proc.communicate()
+    if proc.returncode == 0:
+      return b""
+    else:
+      return stdout + stderr
 
   def check_output(self, output, expected, line_no):
     if expected and not output:

--- a/test_suite/testdata/go/assign.star
+++ b/test_suite/testdata/go/assign.star
@@ -12,7 +12,7 @@ assert_eq(c, 3)
 
 ---
 def f1(): (x,) = 1
-f1() ### (int in sequence assignment|not iterable|got 'int')
+f1() ### (int in sequence assignment|not iterable|got 'int'|operation.*not supported on type)
 ---
 def f2(): a, b, c = 1, 2
 f2() ### (too few values to unpack|unpacked 2 values but expected 3|length mismatch)
@@ -36,7 +36,7 @@ assert_eq(c, 3)
 
 ---
 def f1(): [a, b, c,] = 1
-f1() ### (got int in sequence assignment|not iterable|got 'int')
+f1() ### (got int in sequence assignment|not iterable|got 'int'|operation.*not supported on type)
 ---
 def f2(): [a, b, c] = 1, 2
 f2() ### (too few values to unpack|unpacked 2 values but expected 3|length mismatch)
@@ -102,10 +102,9 @@ f()
 
 ---
 
-# Top level reassignments aren't allowed
-
-z = 0
-z += 3 ### (cannot reassign|augmented assignment|read only)
+# _inconsistency_: go implementation doesn't allow top level reassignments
+# z = 0
+# z += 3
 
 ---
 

--- a/test_suite/testdata/go/bool.star
+++ b/test_suite/testdata/go/bool.star
@@ -40,20 +40,20 @@ assert_eq(1 if "" else 0, 0)
 assert_eq(0 or "" or [] or 0, 0)
 assert_eq(0 or "" or [] or 123 or 1 // 0, 123)
 ---
-0 or "" or [] or 0 or 1 // 0 ### division by zero
+0 or "" or [] or 0 or 1 // 0 ### (division by zero|divide by zero)
 ---
 
 # 'and' yields the first false operand, or the last if all are true.
 assert_eq(1 and "a" and [1] and 123, 123)
 assert_eq(1 and "a" and [1] and 0 and 1 // 0, 0)
 ---
-1 and "a" and [1] and 123 and 1 // 0 ### division by zero
+1 and "a" and [1] and 123 and 1 // 0 ### (division by zero|divide by zero)
 ---
 
 # Built-ins that want a bool want an actual bool, not a truth value.
 # See github.com/bazelbuild/starlark/issues/30
 assert_eq(''.splitlines(True), [])
 ---
-''.splitlines(1) ### (got.*want|expected bool)
+''.splitlines(1) ### (got.*want|expected bool|type of parameter.*doesn't match)
 ---
-''.splitlines("hello") ### (got.*want|expected bool)
+''.splitlines("hello") ### (got.*want|expected bool|type of parameter.*doesn't match)

--- a/test_suite/testdata/go/builtins.star
+++ b/test_suite/testdata/go/builtins.star
@@ -61,11 +61,11 @@ assert_eq(sorted(["two", "three", "four"], key=len, reverse=True),
         ["three", "four", "two"])
 
 ---
-sorted(1) ### (for parameter iterable: got int, want iterable|not a collection|not iterable)
+sorted(1) ### (for parameter iterable: got int, want iterable|not a collection|not iterable|operation.*not supported)
 ---
-sorted([1, 2, None, 3]) ### (not implemented|cannot compare)
+sorted([1, 2, None, 3]) ### (not implemented|cannot compare|operation.*not supported)
 ---
-sorted([1, "one"]) ### (string < int not implemented|cannot compare)
+sorted([1, "one"]) ### (string < int not implemented|cannot compare|operation.*not supported)
 ---
 # _inconsistency_: java accepts key to be None
 # sorted([1, 2, 3], key=None) ## (want callable|not supported)
@@ -174,7 +174,7 @@ assert_eq(max("one", "two", "three", "four"), "two")
 ---
 min() ### (at least one (positional argument|item)|empty)
 ---
-min(1) ### not iterable
+min(1) ### (not iterable|operation.*not supported)
 ---
 min([]) ### (empty|expected at least one item)
 ---
@@ -200,7 +200,7 @@ z1.append(2)
 assert_eq(zip(z1), [(1,), (2,)])
 z1.append(3)
 ---
-zip([1, 2, 3], 1) ### not iterable
+zip([1, 2, 3], 1) ### (not iterable|operation.*not supported)
 ---
 
 # dir for builtin_function_or_method

--- a/test_suite/testdata/go/dict.star
+++ b/test_suite/testdata/go/dict.star
@@ -161,14 +161,14 @@ def iterator1():
   dict = {1:1, 2:1}
   for k in dict:
     dict[2*k] = dict[k]
-iterator1() ### (insert.*during iteration|cannot mutate|temporarily immutable)
+iterator1() ### (insert.*during iteration|cannot mutate|temporarily immutable|mutate an iterable)
 ---
 
 def iterator2():
   dict = {1:1, 2:1}
   for k in dict:
     dict.pop(k)
-iterator2() ### (delete.*during iteration|cannot mutate|temporarily immutable)
+iterator2() ### (delete.*during iteration|cannot mutate|temporarily immutable|mutate an iterable)
 ---
 
 def f(d):
@@ -176,7 +176,7 @@ def f(d):
 def iterator3():
   dict = {1:1, 2:1}
   _ = [f(dict) for x in dict]
-iterator3() ### (insert.*during iteration|cannot mutate|temporarily immutable)
+iterator3() ### (insert.*during iteration|cannot mutate|temporarily immutable|mutate an iterable)
 ---
 
 # This assignment is not a modification-during-iteration:
@@ -187,7 +187,8 @@ def f():
   a, x[0] = x
   assert_eq(a, 1)
   assert_eq(x, {1: 2, 2: 4, 0: 2})
-f()
+# _inconsistency_: rust thinks there is a modification-during-iteration here
+#f()
 
 # Regression test for a bug in hashtable.delete
 def test_delete():
@@ -227,9 +228,9 @@ test_delete()
 
 ---
 # Regression test for github.com/google/starlark-go/issues/128.
-dict(None) ### (got NoneType, want iterable|cannot be none|not iterable)
+dict(None) ### (got NoneType, want iterable|cannot be none|not iterable|operation.*not supported)
 ---
-{}.update(None) ### (got NoneType, want iterable|cannot be none|expected list or dict)
+{}.update(None) ### (got NoneType, want iterable|cannot be none|expected list or dict|operation.*not supported)
 ---
 # Verify position of an "unhashable key" error in a dict literal.
 

--- a/test_suite/testdata/go/function.star
+++ b/test_suite/testdata/go/function.star
@@ -25,7 +25,8 @@ def fib(x):
   if x < 2:
     return x
   return fib(x-2) + fib(x-1)
-fib(10) ### (recursive|Recursion was detected)
+# _inconsistency_: rust fails to detect recursion
+# fib(10) ## (recursive|Recursion was detected)
 ---
 
 # _inconsistency_: java does not support lambda
@@ -52,7 +53,8 @@ def double(x): return x+x
 assert_eq(map(double, [1, 2, 3]), [2, 4, 6])
 assert_eq(map(double, ["a", "b", "c"]), ["aa", "bb", "cc"])
 def mapdouble(x): return map(double, x)
-map(mapdouble, ([1, 2, 3], ["a", "b", "c"])) ### (recursive|Recursion was detected)
+# _inconsistency_: rust fails to detect recursion
+# map(mapdouble, ([1, 2, 3], ["a", "b", "c"])) ## (recursive|Recursion was detected)
 # With the -recursion option it would yield [[2, 4, 6], ["aa", "bb", "cc"]].
 ---
 
@@ -159,7 +161,7 @@ f(
     33, 34, 35, 36, 37, 38, 39, 40,
     41, 42, 43, 44, 45, 46, 47, 48,
     49, 50, 51, 52, 53, 54, 55, 56,
-    57, 58, 59, 60, 61, 62, 63, 64) ### (missing 1 .*argument|not enough parameters)
+    57, 58, 59, 60, 61, 62, 63, 64) ### (missing 1 .*argument|not enough parameters|missing parameter)
 ---
 def f(a, b, c, d, e, f, g, h,
       i, j, k, l, m, n, o, p,
@@ -181,7 +183,7 @@ f(
     41, 42, 43, 44, 45, 46, 47, 48,
     49, 50, 51, 52, 53, 54, 55, 56,
     57, 58, 59, 60, 61, 62, 63, 64, 65,
-    mm = 100) ### (multiple values|argument 'mm' passed both by position and by name|Extraneous parameter)
+    mm = 100) ### (multiple values|argument 'mm' passed both by position and by name|Extraneous parameter|occurs both explicitly and in \*\*kwargs)
 
 ---
 # Regression test for github.com/google/starlark-go/issues/21,

--- a/test_suite/testdata/go/int.star
+++ b/test_suite/testdata/go/int.star
@@ -88,7 +88,8 @@ compound()
 # We follow Python 3 here, but I can't see the method in its madness.
 # int from bool/int/float
 ---
-int() ### (missing .*argument|not enough parameters)
+# _inconsistency_: rust allows int() without parameters
+# int() ## (missing .*argument|not enough parameters)
 ---
 assert_eq(int(False), 0)
 assert_eq(int(True), 1)
@@ -163,15 +164,15 @@ assert_eq(int("0b00000", 0), 0)
 assert_eq(11111 * 11111, 123454321)
 
 ---
-int("0x123", 8) ### (invalid literal.*base 8|not a base 8)
+int("0x123", 8) ### (invalid literal.*base 8|not a base 8|not a valid number in base 8)
 ---
-int("-0x123", 8) ### (invalid literal.*base 8|not a base 8)
+int("-0x123", 8) ### (invalid literal.*base 8|not a base 8|not a valid number in base 8)
 ---
-int("0o123", 16) ### (invalid literal.*base 16|not a base 16)
+int("0o123", 16) ### (invalid literal.*base 16|not a base 16|not a valid number in base 16)
 ---
-int("-0o123", 16) ### (invalid literal.*base 16|not a base 16)
+int("-0o123", 16) ### (invalid literal.*base 16|not a base 16|not a valid number in base 16)
 ---
-int("0x110", 2) ### (invalid literal.*base 2|not a base 2)
+int("0x110", 2) ### (invalid literal.*base 2|not a base 2|not a valid number in base 2)
 ---
 # int from string, auto detect base
 assert_eq(int("123", 0), 123)
@@ -193,7 +194,7 @@ assert_eq(int("-0o123", 0), -83)
 
 
 # github.com/google/starlark-go/issues/108
-int("0Oxa", 8) ### (invalid literal|not a base 8)
+int("0Oxa", 8) ### (invalid literal|not a base 8|not a valid number in base 8)
 ---
 
 # _inconsistency_: some implementations allow some of these conversions

--- a/test_suite/testdata/go/list.star
+++ b/test_suite/testdata/go/list.star
@@ -42,9 +42,9 @@ f2() ### (out of range|out of bound)
 # list + list
 assert_eq([1, 2, 3] + [3, 4, 5], [1, 2, 3, 3, 4, 5])
 
-[1, 2] + (3, 4) ### (unknown.*list \+ tuple|unsupported binary|parameters mismatch)
+[1, 2] + (3, 4) ### (unknown.*list \+ tuple|unsupported binary|parameters mismatch|operation.*not supported)
 ---
-(1, 2) + [3, 4] ### (unknown.*tuple \+ list|unsupported binary|parameters mismatch)
+(1, 2) + [3, 4] ### (unknown.*tuple \+ list|unsupported binary|parameters mismatch|operation.*not supported)
 ---
 abc = ["a", "b", "c"]
 
@@ -166,7 +166,7 @@ def f5():
     x = []
     x += 1
 
-f5() ### ((unknown|unsupported) binary op|parameters mismatch)
+f5() ### ((unknown|unsupported) binary op|parameters mismatch|operation.*not supported)
 ---
 
 # append
@@ -258,7 +258,7 @@ def iterator1():
         list[x] = 2 * x
     return list
 
-iterator1() ### (assign to element.* during iteration|temporarily immutable|Cannot mutate)
+iterator1() ### (assign to element.* during iteration|temporarily immutable|Cannot mutate|mutate an iterable)
 ---
 
 def iterator2():
@@ -266,7 +266,7 @@ def iterator2():
     for x in list:
         list.remove(x)
 
-iterator2() ### (remove.*during iteration|temporarily immutable|Cannot mutate)
+iterator2() ### (remove.*during iteration|temporarily immutable|Cannot mutate|mutate an iterable)
 ---
 
 def iterator3():
@@ -274,7 +274,7 @@ def iterator3():
     for x in list:
         list.append(3)
 
-iterator3() ### (append.*during iteration|temporarily immutable|Cannot mutate)
+iterator3() ### (append.*during iteration|temporarily immutable|Cannot mutate|mutate an iterable)
 ---
 
 def iterator4():
@@ -282,7 +282,7 @@ def iterator4():
     for x in list:
         list.extend([3, 4])
 
-iterator4() ### (extend.*during iteration|temporarily immutable|Cannot mutate)
+iterator4() ### (extend.*during iteration|temporarily immutable|Cannot mutate|mutate an iterable)
 ---
 
 def f(x):
@@ -292,4 +292,4 @@ def iterator5():
     list = [1, 2, 3]
     _ = [f(list) for x in list]
 
-iterator5() ### (append.*during iteration|temporarily immutable|Cannot mutate)
+iterator5() ### (append.*during iteration|temporarily immutable|Cannot mutate|mutate an iterable)

--- a/test_suite/testdata/go/misc.star
+++ b/test_suite/testdata/go/misc.star
@@ -1,21 +1,21 @@
 # Miscellaneous tests of Starlark evaluation.
 
 # Ordered comparisons require values of the same type.
-None < False ### (not impl|cannot compare)
+None < False ### (not impl|cannot compare|operation.*not supported)
 ---
-False < list ### (not impl|cannot compare)
+False < list ### (not impl|cannot compare|operation.*not supported)
 ---
-list < {} ### (not impl|cannot compare)
+list < {} ### (not impl|cannot compare|operation.*not supported)
 ---
-{} < None ### (not impl|cannot compare)
+{} < None ### (not impl|cannot compare|operation.*not supported)
 ---
-None < 0 ### (not impl|cannot compare)
+None < 0 ### (not impl|cannot compare|operation.*not supported)
 ---
-0 < [] ### (not impl|cannot compare)
+0 < [] ### (not impl|cannot compare|operation.*not supported)
 ---
-[] < "" ### (not impl|cannot compare)
+[] < "" ### (not impl|cannot compare|operation.*not supported)
 ---
-"" < () ### (not impl|cannot compare)
+"" < () ### (not impl|cannot compare|operation.*not supported)
 ---
 
 # _inconsistency_: cyclic data structures not supported in Rust and Java
@@ -76,8 +76,8 @@ assert_eq([] + [1] + [2, 3], [1, 2, 3])
 assert_eq([] + [1] + l + [2, 3], [1, 4, 2, 3])
 
 ---
-"a" + "b" + 1 + "c" ### ((unknown|unsupported) binary op|parameters mismatch)
+"a" + "b" + 1 + "c" ### ((unknown|unsupported) binary op|parameters mismatch|operation.*not supported)
 ---
-() + () + 1 + () ### ((unknown|unsupported) binary op|parameters mismatch)
+() + () + 1 + () ### ((unknown|unsupported) binary op|parameters mismatch|operation.*not supported)
 ---
-[] + [] + 1 + [] ### ((unknown|unsupported) binary op|parameters mismatch)
+[] + [] + 1 + [] ### ((unknown|unsupported) binary op|parameters mismatch|operation.*not supported)

--- a/test_suite/testdata/go/string.star
+++ b/test_suite/testdata/go/string.star
@@ -109,7 +109,7 @@ assert_eq("abc"[2], "c")
 # x[i] = ...
 x2 = "abc"
 def f(): x2[1] = 'B'
-f() ### (string.*does not support.*assignment|not supported|can only assign an element in a dictionary or a list)
+f() ### (string.*does not support.*assignment|not supported|can only assign an element in a dictionary or a list|immutable)
 ---
 
 # slicing, x[i:j]
@@ -188,11 +188,11 @@ gothash = {s: hash(s) for s in wanthash}
 assert_eq("%s %r" % ("hi", "hi"), 'hi "hi"')
 assert_eq("%%d %d" % 1, "%d 1")
 ---
-"%d %d" % 1 ### (not enough arguments|not iterable)
+"%d %d" % 1 ### (not enough arguments|not iterable|operation.*not supported)
 ---
 "%d %d" % (1, 2, 3) ### (too many arguments for format string|not all arguments converted)
 ---
-"" % 1 ### (too many arguments for format string|not all arguments converted|not iterable)
+"" % 1 ### (too many arguments for format string|not all arguments converted|not iterable|operation.*not supported)
 ---
 # _inconsistency_: java doesn't support format character %c
 # %c
@@ -241,7 +241,7 @@ assert_eq("{012}".format(*range(100)), "12") # decimal, despite leading zeros
 ---
 assert_eq("a{010}b".format(0,1,2,3,4,5,6,7,8,9,10), "a10b") # index is decimal
 ---
-"a{}b{1}c".format(1, 2) ### (cannot switch from automatic field numbering to manual|manual and automatic)
+"a{}b{1}c".format(1, 2) ### (cannot switch from automatic field numbering to manual|manual.* and automatic.*)
 ---
 # _inconsistency_: java doesn't support '!' in format
 # assert_eq("a{!s}c".format("b"), "abc")
@@ -368,27 +368,27 @@ assert_(not "foo".endswith("x"))
 assert_("foo".startswith("fo"))
 assert_(not "foo".startswith("x"))
 ---
-"foo".startswith(1) ### (got.*want|expected string)
+"foo".startswith(1) ### (got.*want|expected string|type of parameter.*doesn't match)
 ---
-# _inconsistency_: rust startswith accepts only string, not tuple
-# assert_('abc'.startswith(('a', 'A')))
-# assert_('ABC'.startswith(('a', 'A')))
-# assert_(not 'ABC'.startswith(('b', 'B')))
+assert_('abc'.startswith(('a', 'A')))
+assert_('ABC'.startswith(('a', 'A')))
+assert_(not 'ABC'.startswith(('b', 'B')))
 ---
-# _inconsistency_: rust startswith accepts only string not tuple
-# '123'.startswith((1, 2)) ## got int, for element 0
+'123'.startswith((1, 2)) ### (got int, for element 0|type of parameter.*doesn't match)
 ---
-'123'.startswith(['3']) ### (got.*want|expected string)
+# _inconsistency_: rust startswith allows a list, not just tuple
+# https://github.com/facebookexperimental/starlark-rust/issues/23
+# '123'.startswith(['3']) ## (got.*want|expected string|type of parameter.*doesn't match)
 ---
-# _inconsistency_: rust endswith accepts only string, not tuple
-# assert_('abc'.endswith(('c', 'C')))
-# assert_('ABC'.endswith(('c', 'C')))
-# assert_(not 'ABC'.endswith(('b', 'B')))
+assert_('abc'.endswith(('c', 'C')))
+assert_('ABC'.endswith(('c', 'C')))
+assert_(not 'ABC'.endswith(('b', 'B')))
 ---
-# _inconsistency_: rust startswith accepts only string not tuple
-# '123'.endswith((1, 2)) ## got int, for element 0
+'123'.endswith((1, 2)) ### (got int, for element 0|type of parameter.*doesn't match)
 ---
-'123'.endswith(['3']) ### (got.*want|mismatch)
+# _inconsistency_: rust endswith allows a lists, not just tuple
+# https://github.com/facebookexperimental/starlark-rust/issues/23
+# '123'.endswith(['3']) ## (got.*want|mismatch)
 ---
 # _inconsistency_: rust startswith/endswith accept a single argument only
 # start/end
@@ -461,28 +461,28 @@ assert_eq("abc"[1], "b")                       # indexing
 def args(*args): return args
 
 # varargs
-args(*"abc") ### (must be iterable, not string|not iterable|must be an iterable)
+args(*"abc") ### (must be iterable, not string|not iterable|must be an iterable|operation.*not supported)
 ---
 # list(str)
-list("abc") ### (got string, want iterable|not iterable|not a collection)
+list("abc") ### (got string, want iterable|not iterable|not a collection|operation.*not supported)
 ---
 # tuple(str)
-tuple("abc") ### (got string, want iterable|not iterable|not a collection)
+tuple("abc") ### (got string, want iterable|not iterable|not a collection|operation.*not supported)
 ---
 # enumerate
-enumerate("ab") ### (got string, want iterable|not iterable|expected value of type 'sequence')
+enumerate("ab") ### (got string, want iterable|not iterable|expected value of type 'sequence'|operation.*not supported)
 ---
 # sorted
-sorted("abc") ### (got string, want iterable|not iterable|not a collection)
+sorted("abc") ### (got string, want iterable|not iterable|not a collection|operation.*not supported)
 ---
 # list.extend
-[].extend("bc") ### (got string, want iterable|not iterable|expected value of type 'sequence')
+[].extend("bc") ### (got string, want iterable|not iterable|expected value of type 'sequence'|operation.*not supported)
 ---
 # string.join
-",".join("abc") ### (got string, want iterable|not iterable|expected value of type 'sequence')
+",".join("abc") ### (got string, want iterable|not iterable|expected value of type 'sequence'|operation.*not supported)
 ---
 # dict
-dict(["ab"]) ### (not iterable .*string|non-pair element|cannot convert)
+dict(["ab"]) ### (not iterable .*string|non-pair element|cannot convert|operation.*not supported)
 ---
 def for_string():
   for x in "abc":
@@ -490,22 +490,22 @@ def for_string():
 
 # The Java implementation does not correctly reject the following cases:
 # (See Google Issue b/34385336)
-for_string() ### not iterable
+for_string() ### (not iterable|operation.*not supported)
 ---
 # comprehension
-[x for x in "abc"] ### not iterable
+[x for x in "abc"] ### (not iterable|operation.*not supported)
 ---
 # all
-all("abc") ### (got string, want iterable|not iterable)
+all("abc") ### (got string, want iterable|not iterable|operation.*not supported)
 ---
 # any
-any("abc") ### (got string, want iterable|not iterable)
+any("abc") ### (got string, want iterable|not iterable|operation.*not supported)
 ---
 # reversed
-reversed("abc") ### (got.*want|not iterable)
+reversed("abc") ### (got.*want|not iterable|operation.*not supported)
 ---
 # zip
-zip("ab" , "cd") ### (not iterable: string|not iterable)
+zip("ab" , "cd") ### (not iterable: string|not iterable|operation.*not supported)
 ---
 
 # str.join
@@ -516,9 +516,9 @@ assert_eq(','.join(["a", "b", "c"]), 'a,b,c')
 assert_eq(','.join(("a", "b", "c")), 'a,b,c')
 assert_eq(''.join(("a", "b", "c")), 'abc')
 ---
-''.join(None) ### (got NoneType, want iterable|not iterable|parameter 'elements' cannot be None)
+''.join(None) ### (got NoneType, want iterable|not iterable|parameter 'elements' cannot be None|operation.*not supported)
 ---
-''.join(["one", 2]) ### (join: in list, want string, got int|expected string|must be a string)
+''.join(["one", 2]) ### (join: in list, want string, got int|expected string|must be a string|type of parameter.*doesn't match)
 ---
 
 # _inconsistency_: string.capitalize works differently in rust

--- a/test_suite/testdata/go/tuple.star
+++ b/test_suite/testdata/go/tuple.star
@@ -36,7 +36,7 @@ assert_eq(tuple(["a", "b", "c"]), ("a", "b", "c"))
 assert_eq(tuple(["a", "b", "c"]), ("a", "b", "c"))
 assert_eq(tuple([1]), (1,))
 ---
-tuple(1) ### (got int, want iterable|not iterable|not a collection)
+tuple(1) ### (got int, want iterable|not iterable|not a collection|operation.*not supported)
 ---
 
 # tuple * int,  int * tuple

--- a/test_suite/testdata/java/all_any.star
+++ b/test_suite/testdata/java/all_any.star
@@ -34,10 +34,10 @@ assert_eq(any({1 : None, '' : None}), True)
 assert_eq(any({None : 1, '' : 2}), False)
 
 ---
-all(None) ### iterable
+all(None) ### (iterable|operation.*not supported)
 ---
-any(None) ### iterable
+any(None) ### (iterable|operation.*not supported)
 ---
-any(1) ### iterable
+any(1) ### (iterable|operation.*not supported)
 ---
-all(1) ### iterable
+all(1) ### (iterable|operation.*not supported)

--- a/test_suite/testdata/java/int.star
+++ b/test_suite/testdata/java/int.star
@@ -61,6 +61,6 @@ def compound():
 compound()
 
 ---
-1 // 0  ### division by zero
+1 // 0  ### (division by zero|divide by zero)
 ---
-1 % 0  ### (integer modulo by zero|division by zero)
+1 % 0  ### (integer modulo by zero|division by zero|divide by zero)

--- a/test_suite/testdata/java/int_constructor.star
+++ b/test_suite/testdata/java/int_constructor.star
@@ -19,15 +19,15 @@ assert_eq(int('0XFF', 0), 255)
 assert_eq(int('0xFF', 16), 255)
 
 ---
-int('1.5') ### (invalid literal|not a base 10)
+int('1.5') ### (invalid literal|not a base 10|not a valid number in base 10)
 ---
-int('ab') ### (invalid literal|not a base 10)
+int('ab') ### (invalid literal|not a base 10|not a valid number in base 10)
 ---
 int(None) ### None
 ---
-int('123', 3) ### (invalid literal|not a base 3)
+int('123', 3) ### (invalid literal|not a base 3|not a valid number in base 3)
 ---
-int('FF', 15) ### (invalid literal|not a base 15)
+int('FF', 15) ### (invalid literal|not a base 15|not a valid number in base 15)
 ---
 int('123', -1) ### >= 2 (and|&&) <= 36
 ---
@@ -35,7 +35,7 @@ int('123', 1) ### >= 2 (and|&&) <= 36
 ---
 int('123', 37) ### >= 2 (and|&&) <= 36
 ---
-int('0xFF', 8) ### (invalid literal|not a base 8)
+int('0xFF', 8) ### (invalid literal|not a base 8|not a valid number in base 8)
 ---
 int(True, 2) ### (can't convert non-string with explicit base|non-string)
 ---

--- a/test_suite/testdata/java/int_function.star
+++ b/test_suite/testdata/java/int_function.star
@@ -3,17 +3,19 @@ assert_eq(int(0), 0)
 assert_eq(int(42), 42)
 assert_eq(int(-1), -1)
 assert_eq(int(2147483647), 2147483647)
+# _inconsistency_: rust doesn't allow -2147483648 as an int value
 # -2147483648 is not actually a valid int literal even though it's a
 # valid int value, hence the -1 expression.
-assert_eq(int(-2147483647 - 1), -2147483647 - 1)
+# assert_eq(int(-2147483647 - 1), -2147483647 - 1)
 assert_eq(int(True), 1)
 assert_eq(int(False), 0)
 
 ---
 int(None) ### None
 ---
+# _inconsistency_: rust allows int() without an argument
 # This case is allowed in Python but not Skylark
-int() ### (required positional argument|not enough parameters|missing argument)
+# int() ## (required positional argument|not enough parameters|missing argument)
 ---
 
 # string, no base
@@ -22,7 +24,8 @@ assert_eq(int('0'), 0)
 assert_eq(int('42'), 42)
 assert_eq(int('-1'), -1)
 assert_eq(int('2147483647'), 2147483647)
-assert_eq(int('-2147483648'), -2147483647 - 1)
+# _inconsistency_: rust doesn't allow -2147483648 as an int value
+# assert_eq(int('-2147483648'), -2147483647 - 1)
 # Leading zero allowed when not using base = 0.
 assert_eq(int('016'), 16)
 # Leading plus sign allowed for strings.
@@ -34,18 +37,18 @@ assert_eq(int('+42'), 42)
 ---
 # int(-2147483649) ## invalid base-10 integer constant: 2147483649
 ---
-int('') ### (cannot be empty|invalid literal|not a base 10)
+int('') ### (cannot be empty|invalid literal|not a base 10|not a valid number in base 10)
 ---
 # Surrounding whitespace is not allowed
-int('  42  ') ### (invalid literal|not a base 10)
+int('  42  ') ### (invalid literal|not a base 10|not a valid number in base 10)
 ---
-int('-') ### (invalid literal|not a base 10)
+int('-') ### (invalid literal|not a base 10|not a valid number in base 10)
 ---
-int('0x') ### (invalid literal|not a base 16)
+int('0x') ### (invalid literal|not a base 16|not a valid number in base 16)
 ---
-int('1.5') ### (invalid literal|not a base 10)
+int('1.5') ### (invalid literal|not a base 10|not a valid number in base 10)
 ---
-int('ab') ### (invalid literal|not a base 10)
+int('ab') ### (invalid literal|not a base 10|not a valid number in base 10)
 ---
 
 assert_eq(int('11', 2), 3)
@@ -64,9 +67,9 @@ assert_eq(int('016', 16), 22)
 # invalid base
 # int('016', 0) ## base.*016
 ---
-int('123', 3) ### (invalid literal|not a base 3)
+int('123', 3) ### (invalid literal|not a base 3|not a valid number in base 3)
 ---
-int('FF', 15) ### (invalid literal|not a base 15)
+int('FF', 15) ### (invalid literal|not a base 15|not a valid number in base 15)
 ---
 int('123', -1) ### >= 2 (and|&&) <= 36
 ---
@@ -88,7 +91,7 @@ assert_eq(int('0XFF', 0), 255)
 assert_eq(int('0xFF', 16), 255)
 
 ---
-int('0xFF', 8) ### (invalid literal|not a base 8)
+int('0xFF', 8) ### (invalid literal|not a base 8|not a valid number in base 8)
 ---
 int(True, 2) ### (can't convert non-string with explicit base|non-string)
 ---

--- a/test_suite/testdata/java/list_mutation.star
+++ b/test_suite/testdata/java/list_mutation.star
@@ -43,7 +43,7 @@ assert_eq(foo, ['a', 'b', 'c', 'd', 'e', 'f'])
 ---
 (1, 2).extend([3, 4]) ### (no (field or method 'extend|\.extend field)|not supported)
 ---
-[1, 2].extend(3) ### (expected value of type|got int, want iterable|not iterable)
+[1, 2].extend(3) ### (expected value of type|got int, want iterable|not iterable|operation.*not supported on type)
 
 # remove
 

--- a/test_suite/testdata/java/min_max.star
+++ b/test_suite/testdata/java/min_max.star
@@ -33,13 +33,13 @@ assert_eq(max(1, 1, 1, 1, 1, 1), 1)
 assert_eq(max([1, 1, 1, 1, 1, 1]), 1)
 
 ---
-min(1)  ### not iterable
+min(1)  ### (not iterable|operation.*not supported on type)
 ---
 min([])  ### (expected at least one item|empty)
 ---
 max([]) ### (expected at least one item|empty)
 ---
-max(1) ### not iterable
+max(1) ### (not iterable|operation.*not supported on type)
 ---
 
 # _inconsistency_: rust supports comparision between ints and strings

--- a/test_suite/testdata/java/reversed.star
+++ b/test_suite/testdata/java/reversed.star
@@ -9,9 +9,9 @@ assert_eq(reversed([]), [])
 # assert_eq(reversed('bbb'.elems()), ['b', 'b', 'b'])
 
 ---
-reversed(None) ### (got.*want|got NoneType, want iterable|not iterable)
+reversed(None) ### (got.*want|got NoneType, want iterable|not iterable|operation.*not supported on type)
 ---
-reversed(1) ### (got.*want|not iterable)
+reversed(1) ### (got.*want|not iterable|operation.*not supported on type)
 ---
 # _inconsistency_: go, rust reversed() accepts dict as argument
 # reversed({1: 3}) ## Argument to reversed() must be a sequence, not a dictionary

--- a/test_suite/testdata/java/string_misc.star
+++ b/test_suite/testdata/java/string_misc.star
@@ -50,9 +50,9 @@ assert_eq('abababa'.index('ab', 1), 2)
 assert_eq('banana'.rindex('na'), 4)
 assert_eq('abababa'.rindex('ab', 1), 4)
 ---
-'banana'.index('foo') ### substring (\"foo\" )?not found
+'banana'.index('foo') ### substring ([\'\"]foo[\"\'] )?not found
 ---
-'banana'.rindex('foo') ### substring (\"foo\" )?not found
+'banana'.rindex('foo') ### substring ([\'\"]foo[\"\'] )?not found
 ---
 
 # endswith
@@ -61,30 +61,33 @@ assert_eq('a'.endswith(''), True)
 assert_eq(''.endswith(''), True)
 assert_eq('Apricot'.endswith('co'), False)
 
-# _inconsistency_: rust endwith() accepts only a single argument
+# _inconsistency_: rust endswith() accepts only one parameter
 # assert_eq('Apricot'.endswith('co', -1), False)
 # assert_eq('abcd'.endswith('c', -2, -1), True)
 # assert_eq('abcd'.endswith('c', 1, 8), False)
 # assert_eq('abcd'.endswith('d', 1, 8), True)
-# assert_eq('Apricot'.endswith(('cot', 'toc')), True)
-# assert_eq('Apricot'.endswith(('toc', 'cot')), True)
-# assert_eq('a'.endswith(('', '')), True)
-# assert_eq('a'.endswith(('', 'a')), True)
-# assert_eq('a'.endswith(('a', 'a')), True)
-# assert_eq(''.endswith(('a', '')), True)
-# assert_eq(''.endswith(('', '')), True)
-# assert_eq(''.endswith(('a', 'a')), False)
-# assert_eq('a'.endswith(('a')), True)
-# assert_eq('a'.endswith(('a',)), True)
-# assert_eq('a'.endswith(('b',)), False)
-# assert_eq('a'.endswith(()), False)
-# assert_eq(''.endswith(()), False)
+
+assert_eq('Apricot'.endswith(('cot', 'toc')), True)
+assert_eq('Apricot'.endswith(('toc', 'cot')), True)
+assert_eq('a'.endswith(('', '')), True)
+assert_eq('a'.endswith(('', 'a')), True)
+assert_eq('a'.endswith(('a', 'a')), True)
+assert_eq(''.endswith(('a', '')), True)
+assert_eq(''.endswith(('', '')), True)
+assert_eq(''.endswith(('a', 'a')), False)
+assert_eq('a'.endswith(('a')), True)
+assert_eq('a'.endswith(('a',)), True)
+assert_eq('a'.endswith(('b',)), False)
+assert_eq('a'.endswith(()), False)
+assert_eq(''.endswith(()), False)
 ---
-'a'.endswith(['a']) ### (got value of type 'list'|got list|parameters mismatch)
+# _inconsistency_: rust endswith() accepts a list (not just a tuple) as the prefix argument
+# https://github.com/facebookexperimental/starlark-rust/issues/23
+# 'a'.endswith(['a']) # # # (Type of parameter.*doesn't match|got list|parameters mismatch)
+# ---
+'1'.endswith((1,)) ### (Type of parameter.*doesn't match|got int|parameters mismatch)
 ---
-'1'.endswith((1,)) ### (want string|got int|parameters mismatch)
----
-'a'.endswith(('1', 1)) ### (want string|got int|parameters mismatch)
+'a'.endswith(('1', 1)) ### (Type of parameter.*doesn't match|got int|parameters mismatch)
 ---
 
 # startswith
@@ -95,26 +98,27 @@ assert_eq('Apricot'.startswith('z'), False)
 assert_eq(''.startswith(''), True)
 assert_eq(''.startswith('a'), False)
 
-# _inconsistency_: rust startswith() accepts only a single argument
-# assert_eq('Apricot'.startswith(('Apr', 'rpA')), True)
-# assert_eq('Apricot'.startswith(('rpA', 'Apr')), True)
-# assert_eq('a'.startswith(('', '')), True)
-# assert_eq('a'.startswith(('', 'a')), True)
-# assert_eq('a'.startswith(('a', 'a')), True)
-# assert_eq(''.startswith(('a', '')), True)
-# assert_eq(''.startswith(('', '')), True)
-# assert_eq(''.startswith(('a', 'a')), False)
-# assert_eq('a'.startswith(('a')), True)
-# assert_eq('a'.startswith(('a',)), True)
-# assert_eq('a'.startswith(('b',)), False)
-# assert_eq('a'.startswith(()), False)
-# assert_eq(''.startswith(()), False)
+assert_eq('Apricot'.startswith(('Apr', 'rpA')), True)
+assert_eq('Apricot'.startswith(('rpA', 'Apr')), True)
+assert_eq('a'.startswith(('', '')), True)
+assert_eq('a'.startswith(('', 'a')), True)
+assert_eq('a'.startswith(('a', 'a')), True)
+assert_eq(''.startswith(('a', '')), True)
+assert_eq(''.startswith(('', '')), True)
+assert_eq(''.startswith(('a', 'a')), False)
+assert_eq('a'.startswith(('a')), True)
+assert_eq('a'.startswith(('a',)), True)
+assert_eq('a'.startswith(('b',)), False)
+assert_eq('a'.startswith(()), False)
+assert_eq(''.startswith(()), False)
 ---
-'a'.startswith(['a']) ### (got.*want|got list|expected string)
+# _inconsistency_: rust startswith() accepts a list (not just a tuple) as the prefix argument
+# https://github.com/facebookexperimental/starlark-rust/issues/23
+# 'a'.startswith(['a']) # # # (Type of parameter.*doesn't match|got list|expected string)
+# ---
+'1'.startswith((1,)) ### (Type of parameter.*doesn't match|got int|expected string)
 ---
-'1'.startswith((1,)) ### (got.*want|got int|expected string)
----
-'a'.startswith(('1', 1)) ### (got.*want|got int|expected string)
+'a'.startswith(('1', 1)) ### (Type of parameter.*doesn't match|got int|expected string)
 ---
 
 # substring

--- a/test_suite/testdata/rust/bool.star
+++ b/test_suite/testdata/rust/bool.star
@@ -1,3 +1,3 @@
 # Boolean tests
 
-True + 1000 ### (parameters mismatch|unknown binary op|unsupported)
+True + 1000 ### (parameters mismatch|unknown binary op|not supported for types)

--- a/test_suite/testdata/rust/dict.star
+++ b/test_suite/testdata/rust/dict.star
@@ -1,3 +1,3 @@
 # Dict tests
 
-{[]: 1 for x in [1]}    ### (Value is not hashable|unhashable)
+{[]: 1 for x in [1]}    ### (Value of type `list` is not hashable|unhashable)

--- a/test_suite/testdata/rust/josharian_fuzzing.star
+++ b/test_suite/testdata/rust/josharian_fuzzing.star
@@ -24,7 +24,6 @@ assert_eq(0in[1,2,3], False)
 # https://github.com/google/starlark-rust/issues/64: alphabetize dir entries
 assert_eq(dir(""), sorted(dir("")))
 ---
-# https://github.com/google/starlark-rust/issues/66: / is only for floats (which we don't support)
-### rust: not supported
-### java: operator is not allowed
-1 / 1
+# _inconsistency_: starlark spec allows floats and '/' operator; currently, only Java
+# implementation supports it.
+# 1 / 1

--- a/test_suite/testdata/rust/mutation_during_iteration.star
+++ b/test_suite/testdata/rust/mutation_during_iteration.star
@@ -5,14 +5,14 @@ def fun():
   for x in a:
     a.append(1)
 
-fun()  ### (Cannot mutate an iterable while iterating|cannot append|temporarily immutable)
+fun()  ### (mutate an iterable for an iterator while iterating|cannot append|temporarily immutable)
 ---
 def increment_values(dict):
   for k in dict:
     dict[k] += 1
 
 dict = {"one": 1, "two": 2}
-increment_values(dict)   ### (Cannot mutate an iterable while iterating|cannot insert|temporarily immutable)
+increment_values(dict)   ### (mutate an iterable for an iterator while iterating|cannot insert|temporarily immutable)
 ---
 # modifying deep content is allowed
 def modify_deep_content():

--- a/test_suite/testenv.py
+++ b/test_suite/testenv.py
@@ -1,5 +1,5 @@
 STARLARK_BINARY_PATH = {
-    "java": "external/io_bazel/src/main/java/net/starlark/java/cmd/Starlark",
+    "java": "external/io_bazel/src/main/java/net/starlark/java/cmd/starlark",
     "go": "external/net_starlark_go/cmd/starlark/*/starlark",
     "rust": "external/starlark-rust/target/debug/starlark-repl",
 }


### PR DESCRIPTION
Fix Rust implementation repo uri to unbreak buildkite. Otherwise, it fails with 'could not find `Cargo.toml`'.

According to google/starlark-rust, the old repo has been archived.

Needed to fix #200.