### PR TITLE
Add removeprefix/removesuffix to string

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -164,6 +164,8 @@ interact with the environment.
     * [string·lower](#string·lower)
     * [string·lstrip](#string·lstrip)
     * [string·partition](#string·partition)
+    * [string·removeprefix](#string·removeprefix)
+    * [string·removesuffix](#string·removesuffix)
     * [string·replace](#string·replace)
     * [string·rfind](#string·rfind)
     * [string·rindex](#string·rindex)
@@ -3924,6 +3926,30 @@ If S does not contain `x`, `partition` returns `(S, "", "")`.
 
 ```python
 "one/two/three".partition("/")		# ("one", "/", "two/three")
+```
+
+<a id='string·removeprefix'></a>
+### string·removeprefix
+
+`S.removeprefix(prefix)` returns a copy of string S with the prefix `prefix`
+removed if S starts with `prefix`, otherwise it returns S.
+
+```python
+"banana".removeprefix("ban")          # "ana"
+"banana".removeprefix("foo")          # "banana"
+"foofoobar".removeprefix("foo")       # "foobar"
+```
+
+<a id='string·removesuffix'></a>
+### string·removesuffix
+
+`S.removesuffix(suffix)` returns a copy of string S with the suffix `suffix`
+removed if S ends with `suffix`, otherwise it returns S.
+
+```python
+"banana".removesuffix("nana")         # "ba"
+"banana".removesuffix("foo")          # "banana"
+"banana".removesuffix("na")           # "bana"
 ```
 
 <a id='string·replace'></a>


### PR DESCRIPTION
The names and behavior of the new functions `removeprefix` and `removesuffix` are consistent with [PEP 616](https://www.python.org/dev/peps/pep-0616/).

Fixes #185.