### PR TITLE
Generate spec.md table of contents

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,13 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+
+py_binary(
+    name = "spec_md_gen",
+    srcs = ["spec_md_gen.py", "spec_md_gen_lib.py"],
+    data = ["spec.md"],
+)
+
+py_test(
+    name = "spec_md_gen_test",
+    srcs = ["spec_md_gen_test.py", "spec_md_gen_lib.py"],
+    data = ["spec.md"],
+)

--- a/spec.md
+++ b/spec.md
@@ -1,3 +1,8 @@
+<!--
+This file TOC is generated
+Use `bazel run spec_md_gen` to regenerate it in place.
+-->
+
 # Starlark Language Specification
 
 Starlark is a dialect of Python intended for use as a configuration
@@ -50,6 +55,8 @@ interact with the environment.
   * [Overview](#overview)
   * [Contents](#contents)
   * [Lexical elements](#lexical-elements)
+    * [String literals](#string-literals)
+    * [Bytes literals](#bytes-literals)
   * [Data types](#data-types)
     * [None](#none)
     * [Booleans](#booleans)
@@ -95,7 +102,7 @@ interact with the environment.
     * [For loops](#for-loops)
     * [Break and Continue](#break-and-continue)
     * [Load statements](#load-statements)
-    * [Module execution](#module-execution)
+  * [Module execution](#module-execution)
   * [Built-in constants and functions](#built-in-constants-and-functions)
     * [None](#none)
     * [True and False](#true-and-false)
@@ -106,8 +113,8 @@ interact with the environment.
     * [dict](#dict)
     * [dir](#dir)
     * [enumerate](#enumerate)
-    * [fail](#fail)
     * [float](#float)
+    * [fail](#fail)
     * [getattr](#getattr)
     * [hasattr](#hasattr)
     * [hash](#hash)
@@ -120,7 +127,6 @@ interact with the environment.
     * [range](#range)
     * [repr](#repr)
     * [reversed](#reversed)
-    * [set](#set)
     * [sorted](#sorted)
     * [str](#str)
     * [tuple](#tuple)
@@ -128,7 +134,6 @@ interact with the environment.
     * [zip](#zip)
   * [Built-in methods](#built-in-methods)
     * [bytes·elems](#bytes·elems)
-    * [dict·clear](#dict·clear)
     * [dict·get](#dict·get)
     * [dict·items](#dict·items)
     * [dict·keys](#dict·keys)

--- a/spec_md_gen.py
+++ b/spec_md_gen.py
@@ -1,0 +1,10 @@
+import spec_md_gen_lib
+
+
+def main():
+    spec_md = spec_md_gen_lib.gen_spec_md()
+    print(spec_md, end="", file=open("spec.md", mode="w", encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    main()

--- a/spec_md_gen_lib.py
+++ b/spec_md_gen_lib.py
@@ -1,0 +1,45 @@
+import re
+
+
+# Generate `spec.md` file.
+def gen_spec_md() -> str:
+  # State is either:
+  # - reading spec.md before TOC
+  # - reading (and ignoring) TOC
+  # - reading spec.md after TOC
+  state = "BEFORE_TOC"
+
+  before_toc = []
+  toc = []
+  after_toc = []
+
+  for line in open("spec.md", mode="r", encoding="utf-8").readlines():
+    line = line.rstrip()
+
+    if state == "BEFORE_TOC":
+      before_toc += [line]
+
+    heading = line.startswith("##") and not line.startswith("####")
+    heading_contents = line == "## Contents"
+
+    if heading_contents:
+      assert state == "BEFORE_TOC"
+      state = "TOC"
+
+    if heading:
+      # Convert heading to TOC entry.
+      level = len(re.sub("[^#]", "", line))
+      title = re.sub("^#+\s*", "", line)
+      link = re.sub(" ", "-", title.lower())
+      toc += [f" {(level - 2) * 2 * ' '} * [{title}](#{link})"]
+
+    if heading and state == "TOC" and not heading_contents:
+      state = "AFTER_TOC"
+
+    if state == "AFTER_TOC":
+      after_toc += [line]
+
+  assert state == "AFTER_TOC"
+  lines = before_toc + [""] + toc + [""] + after_toc
+
+  return "".join([line + "\n" for line in lines])

--- a/spec_md_gen_test.py
+++ b/spec_md_gen_test.py
@@ -1,0 +1,5 @@
+import spec_md_gen_lib
+
+expected = spec_md_gen_lib.gen_spec_md()
+actual = open("spec.md", mode="r", encoding="utf-8").read()
+assert expected == actual


### PR DESCRIPTION
It was out of sync, but it is correct now.

This diff includes:
* `spec_md_gen.py` script to regenerated `spec.md`
* `spec_md_gen_test.py` test which verifies `spec.md` TOC is in sync
* `spec.md` regenerated