### PR TITLE
.editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Automatically insert trailing newlines in editors which understand
`.editorconfig`, for example, JetBrains IDEs.