### PR TITLE
bazel docs have changed

### DIFF
--- a/users.md
+++ b/users.md
@@ -24,7 +24,7 @@ aim to remove the differences and provide a
 
 ## IDEs
 
-Some IDEs have a [plugin for Bazel](https://docs.bazel.build/versions/master/ide.html).
+Some IDEs have a [plugin for Bazel](https://bazel.build/install/ide).
 Otherwise, consider using a Python mode.
 
 ## Users


### PR DESCRIPTION
The link destination for the IDE link has a big red box at the top saying that the documentation is moving.

> IMPORTANT: The Bazel docs have moved! Please update your bookmark to https://bazel.build/install/ide

> You can [read about](https://blog.bazel.build/2022/02/17/Launching-new-Bazel-site.html) the migration, and let us [know what you think](https://forms.gle/onkAkr2ZwBmcbWXj7).