### PR TITLE
added missing 'x' in hexadecimal escape example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -378,7 +378,7 @@ It is an error if the value of an octal or hexadecimal escape is greater than de
 '\119'			# "\t9"   = "\11" + "9"
 
 '\x00'			# "\x00"  a string containing a single NUL element
-'\0A'			# "\n"    hexadecimal A = decimal 10
+'\x0A'			# "\n"    hexadecimal A = decimal 10
 "\x41-\x5A"             # "A-Z"
 ```
 


### PR DESCRIPTION
The spec says that `\0A` as an escape sequence should evaluate to the newline character (`0x0A` in hex),
when it is actually octal 0 followed by the character 'A'. I believe the spec meant to say `\x0A`, which does
what is described.