### PR TITLE
Note that sorted(reverse) must be a boolean

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3355,7 +3355,7 @@ reversed({"one": 1, "two": 2}.keys())           # ["two", "one"]
 `sorted(x)` returns a new list containing the elements of the iterable sequence x,
 in sorted order.  The sort algorithm is stable.
 
-The optional named parameter `reverse`, if true, causes `sorted` to
+The optional named boolean parameter `reverse`, if true, causes `sorted` to
 return results in reverse sorted order.
 
 The optional named parameter `key` specifies a function of one


### PR DESCRIPTION
Currently the spec says that if reverse is True, then the sort is reversed. But it doesn't say what happens if it's a truthy non-boolean (e.g. 1). Looking at Python, it allows either a boolean or a number (probably for reverse compat), but in the interest of a sensibly implemented subset, suggest we require this to be boolean.