### PR TITLE
Explicitly state that Starlark syntax is strict subset of Python

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -27,7 +27,8 @@ Starlark is an untyped dynamic language with high-level data types,
 first-class functions with lexical scope, and automatic memory
 management or _garbage collection_.
 
-Starlark is strongly influenced by Python, and is almost a subset of
+Starlark is strongly influenced by Python, Starlark syntax is
+a strict subset of Python and Starlark semantics is almost a subset of
 that language.  In particular, its data types and syntax for
 statements and expressions will be very familiar to any Python
 programmer.
@@ -187,6 +188,10 @@ interact with the environment.
   * [Grammar reference](#grammar-reference)
 
 ## Lexical elements
+
+Starlark syntax (but not semantics) is a strict subset of Python syntax.
+Practically it means, tools working with Python AST can be used to work
+with Starlark files.
 
 A Starlark program consists of one or more modules. Each module is defined by a
 single UTF-8-encoded text file.


### PR DESCRIPTION
State that Starlark syntax (but not semantic) is a strict subset of Python, and this property will be maintained in the future iterations of Starlark.

Context: users have asked what tools they can use to work with starlark sources to implement codemods, linters, code formatters, syntax highlighters, documentation generators etc.

One possible option is to recommend Python tools when AST is needed, for example, Python's builtin `ast.parse`. However, to make that recommendation correct, we should guarantee that Starlark syntax (but not semantics) will stay strict subset of Python: so each valid Starlark program could be parsed as Python, and tools won't need to be heaviy rewritten when Starlark language changes.

This PR automatically closes
https://github.com/bazelbuild/starlark/issues/111
as it contravenes this newly established requirement.