### PR TITLE
add Kurtosis as a project that uses Starlark

### DIFF
--- a/users.md
+++ b/users.md
@@ -50,7 +50,7 @@ Otherwise, consider using a Python mode.
 *  [Isopod](https://github.com/cruise-automation/isopod) created by Cruise
    Automation is a DSL framework for Kubernetes configuration. It renders
    Kubernetes objects as Protocol Buffers.
-*  [Kurtosis](https://github.com/kurtosis-tech/kurtosis) is a developer tool for engineers to define and build composable environments for development, testing, and production. Starlark is used as the DSL for defining those environments in a deterministic and readible way, without compromising on usability for complex cases.
+*  [Kurtosis](https://github.com/kurtosis-tech/kurtosis) is a developer tool for engineers to define, build, and run environments for development, testing, and production. Starlark is used as the DSL for defining those environments in a deterministic, reproducible, and readible way, without compromising on usability for complex cases.
 *  [lucicfg](https://chromium.googlesource.com/infra/luci/luci-go/+/refs/heads/master/lucicfg/doc/README.md)
    from Chromium CI is a tool for generating low-level configuration files from Starlark.
 *  [Pixlet](https://github.com/tidbyt/pixlet) is a runtime and UX toolkit for generating animations for small LED displays, such as [Tidbyt](https://tidbyt.com/). Starlark is used to write applets whose outputs are WebP animations.

--- a/users.md
+++ b/users.md
@@ -50,6 +50,7 @@ Otherwise, consider using a Python mode.
 *  [Isopod](https://github.com/cruise-automation/isopod) created by Cruise
    Automation is a DSL framework for Kubernetes configuration. It renders
    Kubernetes objects as Protocol Buffers.
+*  [Kurtosis](https://github.com/kurtosis-tech/kurtosis) is a developer tool for engineers to define and build composable environments for development, testing, and production. Starlark is used as the DSL for defining those environments in a deterministic and readible way, without compromising on usability for complex cases.
 *  [lucicfg](https://chromium.googlesource.com/infra/luci/luci-go/+/refs/heads/master/lucicfg/doc/README.md)
    from Chromium CI is a tool for generating low-level configuration files from Starlark.
 *  [Pixlet](https://github.com/tidbyt/pixlet) is a runtime and UX toolkit for generating animations for small LED displays, such as [Tidbyt](https://tidbyt.com/). Starlark is used to write applets whose outputs are WebP animations.
@@ -72,4 +73,3 @@ Otherwise, consider using a Python mode.
    how to properly escape it. Read also [IBM's blog post](
    https://developer.ibm.com/blogs/yaml-templating-tool-to-simplify-complex-configuration-management/)
    about it.
-*  [Kurtosis](https://github.com/kurtosis-tech/kurtosis) is a developer tool for engineers to define and build composable environments for development, testing, and production.   Starlark is used as the DSL for defining those environments in a deterministic and readible way, without compromising on usability for complex cases.

--- a/users.md
+++ b/users.md
@@ -72,3 +72,4 @@ Otherwise, consider using a Python mode.
    how to properly escape it. Read also [IBM's blog post](
    https://developer.ibm.com/blogs/yaml-templating-tool-to-simplify-complex-configuration-management/)
    about it.
+*  [Kurtosis](https://github.com/kurtosis-tech/kurtosis) is a developer tool for engineers to define and build composable environments for development, testing, and production.   Starlark is used as the DSL for defining those environments in a deterministic and readible way, without compromising on usability for complex cases.


### PR DESCRIPTION
Kurtosis is developer tool for Platform Engineers and DevOps teams to define and spin up complex distributed systems for dev, test, and prod. Kurtosis uses Starlark as the DSL for describing how the environment should be stitched together.