### PR TITLE
add Kurtosis as a project that uses Starlark

### DIFF
--- a/users.md
+++ b/users.md
@@ -50,6 +50,7 @@ Otherwise, consider using a Python mode.
 *  [Isopod](https://github.com/cruise-automation/isopod) created by Cruise
    Automation is a DSL framework for Kubernetes configuration. It renders
    Kubernetes objects as Protocol Buffers.
+*  [Kurtosis](https://github.com/kurtosis-tech/kurtosis) is a developer tool for engineers to package and run environments of containerized services for development, testing, and production. Starlark is used as the DSL for defining those environments in a deterministic, portable, and readable way, without compromising usability for complex cases.
 *  [lucicfg](https://chromium.googlesource.com/infra/luci/luci-go/+/refs/heads/master/lucicfg/doc/README.md)
    from Chromium CI is a tool for generating low-level configuration files from Starlark.
 *  [Pixlet](https://github.com/tidbyt/pixlet) is a runtime and UX toolkit for generating animations for small LED displays, such as [Tidbyt](https://tidbyt.com/). Starlark is used to write applets whose outputs are WebP animations.


### PR DESCRIPTION
This PR should take precedence over #268 , which will be closed shortly. Submitting it via my github username so that the CLA checks pass + I can debug them!

We at Kurtosis use starlark heavily as a language for defining the set up logic of multi-container environments for backend engineers, across dev, test, and prod. Our end users use our DSL, exposed in starlark, to define their environments!