### PR TITLE
Add recur in `users.md`

### DIFF
--- a/users.md
+++ b/users.md
@@ -66,6 +66,10 @@ Otherwise, consider using a Python mode.
 *  [Pixlet](https://github.com/tidbyt/pixlet) is a runtime and UX toolkit for generating animations for small LED displays, such as [Tidbyt](https://tidbyt.com/). Starlark is used to write applets whose outputs are WebP animations.
 *  [qri](http://qri.io/) is versioned, scriptable, exportable,
    collaborative datasets. It uses Starlark to [describe transformations](https://qri.io/docs/reference/starlark_syntax/).
+*  [recur](https://github.com/dbohdan/recur) is a command-line tool that
+   retries a command with exponential backoff plus jitter to mitigate the
+   thundering herd problem. The success condition is written as a Starlark
+   expression.
 *  [Tilt](https://tilt.dev/) manages local development instances for teams that
    deploy to Kubernetes. [Tilt files](https://docs.tilt.dev/tiltfile_concepts.html)
    are written in Starlark.


### PR DESCRIPTION
This PR adds my project [recur](https://github.com/dbohdan/recur) to the list of users. recur is a tool for retrying commands that uses Starlark in a small way: to let the user write a [success condition](https://github.com/dbohdan/recur?tab=readme-ov-file#conditions) for the command. No worries if this isn't enough to include it.

Some background: I have migrated recur from Python and [simpleeval](https://github.com/danthedeckie/simpleeval) to Go and starlark-go. I considered the Common Expression Language but didn't want to change the syntax. I am happy with my choice so far. The user-facing changes with starlark-go are relatively minor. The most noticeable are the lack `is None` and having to replace `code in {1, 3}` with `code in (1, 3)`. Starlark expressions seem a viable alternative to CEL for this kind of task.