### PR TITLE
Add productions for type annotations.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4722,7 +4722,7 @@ Type = identifier [TypeArguments].
 
 TypeArguments = '[' TypeArgument {',' TypeArgument} ']'.
 
-TypeArgument = Type
+TypeArgument = TypeExpr
              | ListOfTypes
              | DictOfTypes
              | string

--- a/spec.md
+++ b/spec.md
@@ -2852,9 +2852,8 @@ type, a colon, and then an indented block of statements which form the body of
 the function.
 
 The parameter list is a comma-separated list whose elements are of
-several kinds. Any parameter name may be associated with a type expression.
-First come zero or more required parameters, which are simple identifiers;
-all calls must provide an argument value for these parameters.
+several kinds.  First come zero or more required parameters, which are
+simple identifiers; all calls must provide an argument value for these parameters.
 
 The required parameters are followed by zero or more optional
 parameters, of the form `name=expression`. The expression specifies
@@ -2871,6 +2870,8 @@ parameters, again of the forms `name` or `name=expression`,
 but these parameters differ from earlier ones in that they are
 _keyword-only_: if a call provides their values, it must do so as
 keyword arguments, not positional ones.
+
+Any parameter name may be associated with a type expression.
 
 Note that even though keyword-only arguments are declared after `*args` in a
 function's definition, they nevertheless must appear before `*args` in a call

--- a/spec.md
+++ b/spec.md
@@ -4725,6 +4725,7 @@ TypeArguments = '[' TypeArgument {',' TypeArgument} ']'.
 TypeArgument = Type
              | ListOfTypes
              | DictOfTypes
+             | string
              .
 
 ListOfTypes = '[' [TypeArgument {',' TypeArgument} [',']] ']'.

--- a/spec.md
+++ b/spec.md
@@ -2852,14 +2852,14 @@ type, a colon, and then an indented block of statements which form the body of
 the function.
 
 The parameter list is a comma-separated list whose elements are of
-several kinds.  First come zero or more required parameters, which are
-simple identifiers with optionally a type annotation; 
+several kinds. Any parameter name may be associated with a type expression.
+First come zero or more required parameters, which are simple identifiers;
 all calls must provide an argument value for these parameters.
 
 The required parameters are followed by zero or more optional
-parameters, of the form `name = expression` or `name: type = expression`.
-The expression specifies the default value for the parameter for use in calls 
-that do not provide an argument value for it.
+parameters, of the form `name=expression`. The expression specifies
+the default value for the parameter for use in calls that do not
+provide an argument value for it.
 
 The required parameters are optionally followed by a single parameter
 name preceded by a `*`.  This is the called the _varargs_ parameter,
@@ -4716,9 +4716,9 @@ LambdaParameter  = identifier ['=' Test]
                  | '**' identifier
                  .
            
-TypeExpr = Type {'|' Type}.
+TypeExpr = TypeAtom {'|' TypeAtom}.
 
-Type = identifier [TypeArguments].
+TypeAtom = identifier [TypeArguments].
 
 TypeArguments = '[' TypeArgument {',' TypeArgument} ']'.
 


### PR DESCRIPTION
Going with the stricter version of productions in comparison with Python.

Pros:
- makes evaluation simpler, there's a lot less to validate
- removes ambiguity between `Dict[(str,str)]==Dict[str,str]` and `List[(int,)] != List[int]`
- stricter syntax can be relaxed later

Cons:
- extends the Parser for additional 100 lines of code 

Issue: https://github.com/bazelbuild/bazel/issues/24407