### PR TITLE
Resolve Iterable, Sequence, Indexable differences

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -566,7 +566,7 @@ every value has a type string that can be obtained with the expression
 expression `str(x)`, or to a Boolean truth value using the expression
 `bool(x)`.  Other operations apply only to certain types.  For
 example, the indexing operation `a[i]` works only with strings, bytes values, lists,
-and tuples, and any application-defined types that are _indexable_.
+and tuples, and any application-defined sequences.
 The [_value concepts_](#value-concepts) section explains the groupings of
 types by the operators they support.
 
@@ -875,7 +875,7 @@ TODO: string.elems(), string.elem_ords(), string.codepoint_ords()
 A list is a mutable sequence of values.
 The [type](#type) of a list is `"list"`.
 
-Lists are indexable sequences: the elements of a list may be iterated
+Lists are sequences: the elements of a list may be iterated
 over by `for`-loops, list comprehensions, and various built-in
 functions.
 
@@ -1762,20 +1762,18 @@ contexts dictionaries act like a sequence of their keys.
 We can classify different kinds of sequence types based on the
 operations they support.
 
-* `Iterable`: an _iterable_ value lets us process each of its elements in a fixed order.
+* `Iterable`: an _iterable_ value lets us process itself (its elements or keys) in a fixed order.
   Examples: `dict`, `list`, `tuple`, `set`, but not `string` or `bytes`.
-* `Sequence`: a _sequence of known length_ lets us know how many elements it
-  contains without processing them.
-  Examples: `dict`, `list`, `tuple`, `set`, but not `string` or `bytes`.
-* `Indexable`: an _indexed_ type has a fixed length and provides efficient
+* `Sequence`: a _sequence of fixed length_ lets us know how many elements it
+  contains without processing them and provides efficient
   random access to its elements, which are identified by integer indices.
-  Examples: `string`, `bytes`, `tuple`, and `list`, but not `dict` or `set`.
+  Examples: `list`, `tuple`, `string`, `bytes`, but not `dict` or `set`.
 * `SetIndexable`: a _settable indexed type_ additionally allows us to modify the
   element at a given integer index. Example: `list`.
 * `Mapping`: a mapping is an association of keys to values. Example: `dict`.
 
 Although all of Starlark's core data types for sequences implement at
-least the `Sequence` contract, it's possible for an an application
+least the `Sequence` contract, it's possible for an application
 that embeds the Starlark interpreter to define additional data types
 representing sequences of unknown length that implement only the `Iterable` contract.
 
@@ -2572,7 +2570,7 @@ f("n")                                          # 2
 
 ### Index expressions
 
-An index expression `a[i]` yields the `i`th element of an _indexable_
+An index expression `a[i]` yields the `i`th element of a sequence
 type such as a string, bytes, tuple, list, or range.  The index `i` must be an `int`
 value in the range -`n` ≤ `i` < `n`, where `n` is `len(a)`; any other
 index results in an error.
@@ -2615,7 +2613,7 @@ type, such as a tuple or string, or a frozen value of a mutable type.
 ### Slice expressions
 
 A slice expression `a[start:stop:stride]` yields a new value containing a
-subsequence of `a`, which must be an indexable sequence such as string,
+subsequence of `a`, which must be a sequence such as string,
 bytes, tuple, list, or range.
 
 ```text


### PR DESCRIPTION
Having 3 different types causes confusion. Simplifying down to only 2 type: Iterables and Sequences, that can be easily discerned.

Previously `dict` and `sets` were `Sequences` but not `Indexable` (because of int indices). Merge together `Sequence` and `Indexable`.

This also brings specs closer to Java implementation.

Addresses: https://github.com/bazelbuild/starlark/issues/206