### PR TITLE
Fix syntax to allow type application without arguments

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4782,7 +4782,7 @@ Type = identifier
      | identifier TypeArguments
      .
 
-TypeArguments = '[' TypeArgument {',' TypeArgument} ']'.
+TypeArguments = '[' [ TypeArgument {',' TypeArgument} ] ']'.
 
 TypeArgument = TypeExpr
              | ListOfTypes


### PR DESCRIPTION
Needed for `(): Tuple[]`.