### PR TITLE
Remove invalid example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2805,8 +2805,6 @@ a, b = 2, 3
 (x, y) = f()
 [zero, one, two] = range(3)
 [] = ()
-
-[(a, b), (c, d)] = ("ab", "cd")
 ```
 
 The same process for assigning a value to a target expression is used


### PR DESCRIPTION
The text states that the example `[(a, b), (c, d)] = ("ab", "cd")` is a valid compound assignment. This example is rejected by Bazel and by starlark-go.

Removing this invalid example.


Fixes #281