### PR TITLE
Fix grammar for slices

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2642,7 +2642,7 @@ that can be indexed with an integer as above, such as `Sequence`s, `string`,
 and `bytes`.
 
 ```text
-SubscriptSuffix = '[' [Expressions] [':' Expression [':' Expression]] ']' .
+SubscriptSuffix = '[' [Expressions] ':' [Expression] [':' [Expression]] ']' .
 ```
 
 A slice expression `a[start:stop:stride]` yields a copy of `a` containing
@@ -4781,7 +4781,7 @@ Operand = identifier
         .
 
 DotSuffix   = '.' identifier .
-SubscriptSuffix = '[' [Expressions] [':' Expression [':' Expression]] ']'
+SubscriptSuffix = '[' [Expressions] ':' [Expression] [':' [Expression]] ']'
                 | '[' Expressions ']'
                 .
 CallSuffix  = '(' [Arguments [',']] ')' .


### PR DESCRIPTION
Fix the grammar for slices to allow expressions of the form `a[0::2]`.

The refactor of the grammar done in ea603026297111a1c8c1ce0c95eb92443d03950d made the unexpected change to disallow this expression.