### PR TITLE
Fix example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2620,8 +2620,8 @@ A subscript expression appearing on the left side of an assignment causes
 the specified sequence element or mapping value to be updated:
 
 ```python
-a = range(10, 13)       # a == [10, 11, 12]
-a[2] = 7                # a == [10, 11, 7]
+a = list(range(10, 13))   # a == [10, 11, 12]
+a[2] = 7                  # a == [10, 11, 7]
 
 coins = {}              # coins == {}
 coins["suzie b"] = 100  # coins == {"suzie b": 100}


### PR DESCRIPTION
Fix an invalid example. The example attempts to do an index assignment on a `range`, this is not allowed as a `range` is immutable.

When running the example, it produces the following error:
Bazel: "Error: can only assign an element in a dictionary or a list, not in a 'range'"
Python: "TypeError: 'range' object does not support item assignment"