### PR TITLE
Remove error condition on dict.get

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3721,7 +3721,7 @@ print(x)                                # {}
 If the dictionary contains no such value, `get` returns `None`, or the
 value of the optional `default` parameter if present.
 
-`get` fails if `key` is unhashable, or the dictionary is frozen or has active iterators.
+`get` fails if `key` is unhashable.
 
 ```python
 x = {"one": 1, "two": 2}


### PR DESCRIPTION
Remove claim that dict·get would produce an error if the dictionary is frozen or has active iterators.

dict·get is a read operation and as such does not produce an error when frozen or with an active iterator. None of the implementations produce an error in this case.