### PR TITLE
Remove the case that dict·update can take `None`

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3811,8 +3811,7 @@ x                                       # {"one": 1, "two": 2, "three": 3, "four
 `D.update([pairs][, name=value[, ...])` makes a series of key/value
 insertions into dictionary D, then returns `None.`
 
-If the positional argument `pairs` is present, it must be `None`,
-another `dict`, or some other iterable.
+If the positional argument `pairs` is present, it must be `dict`, or some other iterable.
 If it is another `dict`, then its key/value pairs are inserted into D.
 If it is an iterable, it must provide a sequence of pairs (or other iterables of length 2),
 each of which is treated as a key/value pair to be inserted into D.


### PR DESCRIPTION
None of the implementations accept `None` as a parameter for dict·update. This includes Bazel, starlark-go and Python. This construction is not accepted.