### PR TITLE
Make the code compatible with Bazel 9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,4 +2,5 @@ module(
     name = "bazelbuild_starlark",
 )
 
+bazel_dep(name = "rules_java", version = "9.3.0")
 bazel_dep(name = "rules_python", version = "1.2.0")

--- a/test_suite/BUILD
+++ b/test_suite/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_import.bzl", "java_import")
 load("@rules_python//python:defs.bzl", "py_test")
 load(":util.bzl", "format_test_name")
 


### PR DESCRIPTION
Starting with Bazel 9, projects must import java_rules explicitly.