### PR TITLE
Clarify the parameter `keepends` in string·splitlines

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4651,9 +4651,9 @@ successive lines of S, that is, the strings formed by splitting S at
 line terminators (currently assumed to be `\n`, `\r` and `\r\n`,
 regardless of platform).
 
-The optional argument, `keepends`, is interpreted as a Boolean.
-If true, line terminators are preserved in the result, though
-the final element does not necessarily end with a line terminator.
+The optional Boolean argument `keepends` defines whether line terminators
+are preserved in the result, though the final element does not necessarily
+end with a line terminator.
 
 ```python
 "A\nB\rC\r\nD".splitlines()     # ["A", "B", "C", "D"]


### PR DESCRIPTION
State that the parameter `keepends` in string·splitlines must be a Boolean.

Fixes #30