### PR TITLE
Clarification on print built-in function

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3495,7 +3495,7 @@ min("two", "three", "four", key=len)            # "two", the shortest
 
 `print(*args, sep=" ")` prints its arguments, followed by a newline.
 Arguments are formatted as if by `str(x)` and separated with a space,
-unless an alternative separator is specified by a `sep` named argument.
+unless an alternative separator is specified by a `sep` string named argument.
 
 Example:
 


### PR DESCRIPTION
Clarified that the named argument `sep` of the built-in function `print` must be a string. This follows the Bazel and star lark-go implementations. Note: Python accepts string or None, this is why the clarification is needed.