### PR TITLE
Fix example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -2442,7 +2442,7 @@ lambda: (a if b else c)              # parens are redunant
 (lambda: a) if b else c              # parens are required
 
 a if b else lambda: (c if d else e)  # parens are redundant
-a if b else (lambda: c if d else e)  # parens are required
+a if b else (lambda: c) if d else e  # parens are required
 (a if b else lambda: c) if d else e  # parens are required
 ```
 


### PR DESCRIPTION
The expression `a if b else (lambda: c if d else e)` is equivalent to `a if b else lambda: (c if d else e)` and the parens are redundant. I think that the author ment to add the alternative `a if b else (lambda: c) if d else e` that does require parens.