### PR TITLE
Add type annotation syntax to the language spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -5113,7 +5113,6 @@ TypeArgument = TypeExpr
              | TypeDict
              | string
              | int
-             | '(' ')'
              | '...'
              .
 

--- a/spec.md
+++ b/spec.md
@@ -1904,14 +1904,13 @@ PrimaryExpr = Operand
             | PrimaryExpr DotSuffix
             | PrimaryExpr CallSuffix
             | PrimaryExpr SubscriptSuffix
-            | CastExpr
-            | IsInstanceExpr
             .
 
 Operand = identifier
         | int | float | string | bytes
         | ListExpr | ListComp
         | DictExpr | DictComp
+        | CastExpr | IsInstanceExpr
         | '(' [Expressions] [,] ')'
         .
 
@@ -2817,15 +2816,16 @@ in `for` statements and in comprehension `for` clauses.
 
 A typed assignment statement may be viewed as syntactic sugar for a [var
 statement](#var-statements) immediately followed by a simple assignment
-statement; it informs the type checker of a newly-bound variable's type and
-assigns the variable an initial value:
+statement; it informs the type checker of a new variable's type and assigns the
+variable an initial value:
 
 ```text
 AssignStmt = identifier ':' TypeExpr '=' Expressions.
 ```
 
-It is a static error for an assignment statement to (re)declare the type of a
-variable that has already been bound:
+A variable may only be associated with a type at the point in code where it is
+bound. Thus, a var statement or a typed assignment statement may only be used
+on a new binding:
 
 ```python
 def f():
@@ -3201,6 +3201,18 @@ A load statement within a function is a static error.
 
 ## Type annotations
 
+Type annotations are used to inform static type checkers for Starlark. The
+semantics of type checking are not specified by this document, but are intended
+to be broadly similar to those of Mypy.
+
+Identifiers in type expressions are resolved statically, following the same
+rules as in value expressions.
+
+Type annotations described below are evaluated statically. However, most code
+(with the exception of the `...` ellipsis token) that may be parsed as a type
+expression may also be parsed as a value expression, and then evaluated
+dynamically.
+
 ### Type expressions
 
 Type expressions consist of one or more *type atoms* separated by the `|`
@@ -3215,14 +3227,22 @@ TypeExpr = TypeAtom
 Semantically, `|` in a type expression means "or" (a union type). For example,
 `int | float | None` denotes "integer or float or `None`".
 
-Type atoms can be plain *type names* (an identifier or a sequence of identifiers
-separated by `.` for namespacing), or *type applications* with type arguments in
-square brackets:
+A type atom can be a plain *type name* (an identifier or a sequence of
+identifiers separated by `.` for namespacing), a *type application* with type
+arguments in square brackets, or a *parenthesized tuple* of type expressions
+(or a single parenthesized type expression).
+
+The rules for parsing parenthesized type expressions and parenthesized tuples
+are identical to those for parsing parenthesized tuples and parenthesized
+expressions in value syntax.
 
 ```
 TypeAtom = TypeName
          | TypeApplication
+         | '(' [TypeExprs [',']] ')'
          .
+
+TypeExprs = TypeExpr {',' TypeExpr}.
 
 TypeName = identifier
          | TypeName DotSuffix
@@ -3233,9 +3253,11 @@ TypeApplication = TypeName '[' TypeArguments ']'.
 
 The *type arguments* of a type application is a non-empty sequence of type
 expressions, lists of type expressions, string-keyed dicts with type expression
-values, strings or integer literals, empty tuples, and/or the special *ellipsis*
-token(s) `...`. For compatibility with subscript expression syntax, type
-arguments _cannot_ have a trailing comma.
+values, strings or integer literals, and/or the special *ellipsis* token(s)
+`...`.
+
+For compatibility with subscript expression syntax, typearguments _cannot_
+have a trailing comma.
 
 ```
 TypeArguments = TypeArgument
@@ -3247,7 +3269,6 @@ TypeArgument = TypeExpr
              | TypeDict
              | string
              | int
-             | '(' ')'
              | '...'
              .
 
@@ -3315,8 +3336,9 @@ x: int
 y: list[int]
 ```
 
-It is a static error for a var statement to (re)declare the type of a variable
-that has already been bound:
+A variable may only be associated with a type at the point in code where it is
+bound. Thus, a var statement or a typed assignment statement may only be used
+on a new binding:
 
 ```python
 def f():
@@ -5004,14 +5026,13 @@ PrimaryExpr = Operand
             | PrimaryExpr DotSuffix
             | PrimaryExpr CallSuffix
             | PrimaryExpr SubscriptSuffix
-            | CastExpr
-            | IsInstanceExpr
             .
 
 Operand = identifier
         | int | float | string | bytes
         | ListExpr | ListComp
         | DictExpr | DictComp
+        | CastExpr | IsInstanceExpr
         | '(' [Expressions [',']] ')'
         .
 
@@ -5064,8 +5085,11 @@ TypeExpr = TypeAtom
          | TypeAtom '|' TypeExpr
          .
 
+TypeExprs = TypeExpr {',' TypeExpr}.
+
 TypeAtom = TypeName
          | TypeApplication
+         | '(' [TypeExprs [',']] ')'
          .
 
 TypeName = identifier

--- a/spec.md
+++ b/spec.md
@@ -2813,6 +2813,26 @@ a, b = 2, 3
 The same process for assigning a value to a target expression is used
 in `for` statements and in comprehension `for` clauses.
 
+#### Typed assignments
+
+A typed assignment statement may be viewed as syntactic sugar for a [var
+statement](#var-statements) immediately followed by a simple assignment
+statement; it informs the type checker of a newly-bound variable's type and
+assigns the variable an initial value:
+
+```text
+AssignStmt = identifier ':' TypeExpr '=' Expressions.
+```
+
+It is a static error for an assignment statement to (re)declare the type of a
+variable that has already been bound:
+
+```python
+def f():
+    x = 123
+    x: int = 456  # static error: type annotation on x may only appear at its first declaration
+```
+
 ### Augmented assignments
 
 An augmented assignment, which has the form `lhs op= rhs` updates the
@@ -2848,26 +2868,6 @@ statements but does not declare a new temporary variable `i`:
 ```python
 i = index()
 a[i] = a[i] * 2
-```
-
-### Typed assignments
-
-A typed assignment statement may be viewed as syntactic sugar for a [var
-statement](#var-statements) immediately followed by a simple assignment
-statement; it informs the type checker of a newly-bound variable's type and
-assigns the variable an initial value:
-
-```text
-AssignStmt = identifier ':' TypeExpr '=' Expressions.
-```
-
-It is a static error for an assignment statement to (re)declare the type of a
-variable that has already been bound:
-
-```python
-def f():
-    x = 123
-    x: int = 456  # static error: type annotation on x may only appear at its first declaration
 ```
 
 ### Function definitions

--- a/spec.md
+++ b/spec.md
@@ -1537,9 +1537,15 @@ The sets of names bound in the file block and in the module block do not overlap
 it is an error for a load statement to bind the name of a global,
 or for a top-level statement to bind a name bound by a load statement.
 
-A file block contains a _function_ block for each top-level
+A file block contains a _function_ block for each non-generic top-level
 function, and a _comprehension_ block for each top-level comprehension.
-Bindings in either of these kinds of block,
+There is a _type parameter_ block for each type alias statement that takes
+type parameters; and for each generic function, a type parameter block
+with a function block nested in it (the type parameter block includes the
+type parameter list, and the function block includes everything that follows
+the type parameter list).
+
+Bindings in any of these 3 kinds of block,
 and in the file block itself, are called _local_.
 (In the example, the bindings for `e`, `f`, `g`, and `i` are all local.)
 Additional functions and comprehensions, and their blocks, may be

--- a/spec.md
+++ b/spec.md
@@ -269,8 +269,9 @@ identifiers:
 and            else           load
 break          for            not
 continue       if             or
-def            in             pass
-elif           lambda         return
+cast           in             pass
+def            isinstance     return
+elif           lambda
 ```
 
 The tokens below also may not be used as identifiers although they do not
@@ -1903,6 +1904,8 @@ PrimaryExpr = Operand
             | PrimaryExpr DotSuffix
             | PrimaryExpr CallSuffix
             | PrimaryExpr SubscriptSuffix
+            | CastExpr
+            | IsInstanceExpr
             .
 
 Operand = identifier
@@ -2810,7 +2813,6 @@ a, b = 2, 3
 The same process for assigning a value to a target expression is used
 in `for` statements and in comprehension `for` clauses.
 
-
 ### Augmented assignments
 
 An augmented assignment, which has the form `lhs op= rhs` updates the
@@ -2848,12 +2850,32 @@ i = index()
 a[i] = a[i] * 2
 ```
 
+### Typed assignments
+
+A typed assignment statement may be viewed as syntactic sugar for a [var
+statement](#var-statements) immediately followed by a simple assignment
+statement; it informs the type checker of a newly-bound variable's type and
+assigns the variable an initial value:
+
+```text
+AssignStmt = identifier ':' TypeExpr '=' Expressions.
+```
+
+It is a static error for an assignment statement to (re)declare the type of a
+variable that has already been bound:
+
+```python
+def f():
+    x = 123
+    x: int = 456  # static error: type annotation on x may only appear at its first declaration
+```
+
 ### Function definitions
 
 A `def` statement creates a named function and assigns it to a variable.
 
 ```text
-DefStmt = 'def' identifier '(' [Parameters [',']] ')' ':' Suite .
+DefStmt = 'def' identifier {'[' TypeParams [','] ']'} '(' [Parameters [',']] ')' {'->' TypeExpr} ':' Suite .
 ```
 
 Example:
@@ -2867,9 +2889,16 @@ twice(2)                # 4
 twice("two")            # "twotwo"
 ```
 
-The function's name is preceded by the `def` keyword and followed by
-the parameter list (which is enclosed in parentheses), a colon, and
-then an indented block of statements which form the body of the function.
+The function's name is preceded by the `def` keyword, is optionally followed by
+the type parameter list (which is enclosed in square brackets), and then is
+followed by the parameter list (which is enclosed in parentheses), optionally an
+arrow and the return type, then a colon, and then an indented block of
+statements which form the body of the function.
+
+The type parameter list is optional. If it is present, it is a non-empty
+comma-separated list of simple identifiers denoting types which may then be used
+in type annotations in the parameter list, in the return type annotation, or the
+function's body. A function with a type parameter list is a *generic function*.
 
 The parameter list is a comma-separated list whose elements are of
 several kinds.  First come zero or more required parameters, which are
@@ -2925,6 +2954,16 @@ This is called the _keyword arguments_ parameter, and accumulates in a
 dictionary any surplus `name=value` arguments that do not match a
 prior parameter. It is conventionally named `**kwargs`.
 
+The name of any parameter in the parameter list except for the bare `*` may
+optionally be followed by a type annotation (a `:` followed by a [type
+expression](#type-expressions)). For ordinary parameters (required, optional, or
+keyword-only), this type expression denotes the type of the parameter itself.
+For the `*args` and `**kwargs` parameters, the type annotations denote the type
+of individual values accumulated by `*args` or `**kwargs` respectively.
+
+Finally, between the parameter list and the `:`, the function may optionally
+annotate its return type by an *arrow* `->` followed by a type expression.
+
 Here are some example parameter lists:
 
 ```python
@@ -2935,6 +2974,14 @@ def f(a, b, c=1, *args): pass
 def f(a, b, c=1, *args, **kwargs): pass
 def f(**kwargs): pass
 def f(a, b, c=1, *, d=1): pass
+```
+
+And some examples of functions declared with type annotations:
+
+```python
+def f() -> None: pass
+def f(a: int, b: list | None = None, *, c=0, **kwargs: str): pass
+def f[T](a: list[T]) -> T: return a[0]
 ```
 
 Execution of a `def` statement creates a new function object.  The
@@ -3152,6 +3199,181 @@ load("module.sky", "x", y2="y", "z")    # assigns x, y2, and z
 
 A load statement within a function is a static error.
 
+## Type annotations
+
+### Type expressions
+
+Type expressions consist of one or more *type atoms* separated by the `|`
+operator:
+
+```
+TypeExpr = TypeAtom
+         | TypeExpr '|' TypeAtom
+         .
+```
+
+Semantically, `|` in a type expression means "or" (a union type). For example,
+`int | float | None` denotes "integer or float or `None`".
+
+Type atoms can be plain *type names* (an identifier or a sequence of identifiers
+separated by `.` for namespacing), or *type applications* with type arguments in
+square brackets:
+
+```
+TypeAtom = TypeName
+         | TypeApplication
+         .
+
+TypeName = identifier
+         | TypeName DotSuffix
+         .
+
+TypeApplication = TypeName '[' [TypeArgument [',']] ']'.
+```
+
+The *type arguments* of a type application is a non-empty sequence of type
+expressions, lists of type expressions, string-keyed dicts with type expression
+values, strings or integer literals, empty tuples, and/or the special *ellipsis*
+token(s) `...`; a trailing comma is allowed:
+
+```
+TypeArguments = [TypeArgument [',']]
+              .
+
+TypeArgument = TypeExpr
+             | TypeList
+             | TypeDict
+             | string
+             | int
+             | '(' ')'
+             | '...'
+             .
+
+TypeList = '[' [TypeExpr [',']] ']'.
+
+TypeDict = '{' [TypeDictEntry [',']] '}'.
+
+TypeDictEntry = string ':' TypeExpr.
+```
+
+Semantically, a type application means a parametrized type; most commonly, a
+type derived from other types. For example `dict[str, int]` denotes "dictionary
+with string keys and integer values", and `Callable[..., bool]` denotes
+"function taking arbitrary arguments and returning a boolean".
+
+### Type alias statements
+
+A type alias statement binds a type expression to a name in the current module.
+Type alias statements must be top-level statements; they are prohibited in
+functions and `for` and `if`/`elif`/`else` bodies.
+
+Syntactically, a type alias looks like `type`, followed by the alias's name with
+optional type parameters, an `=` sign, and the type's definition:
+
+```
+TypeAlisStmt = 'type' identifier {'[' TypeParams [','] ']'} '=' TypeExpr.
+
+TypeParams = identifier {',' TypeParams}.
+```
+
+Examples:
+
+```python
+type Numeric = int | float
+type OptionalDict[K, V] = dict[K, V] | None
+```
+
+Evaluation of a type alias statement introduces a new global variable with an
+implementation-defined marker value.
+
+Just as for assignment statements, it is a static error for a type alias to bind
+a global variable already explicitly bound in the file:
+
+```python
+int_or_str = True
+type int_or_str = int | str  # static error: cannot reassign global int_or_str declared on line 1
+```
+
+### Var statements
+
+A var statement binds a name in the current block and informs the type checker
+of its type, but doesn't assign it a value.
+
+Syntactically, a var statement looks a required function parameter with a type
+annotation:
+
+```
+VarStmt = identifier ':' TypeExpr.
+```
+
+Examples:
+
+```python
+x: int
+y: list[int]
+```
+
+It is a static error for a var statement to (re)declare the type of a variable
+that has already been bound:
+
+```python
+def f():
+    x = 42
+    x: int  # static error: type annotation on x may only appear at its first declaration
+```
+
+It is a dynamic error to evaluate a reference to a variable that has been bound
+by a var statement before it has been assigned a value by an assignment
+statement:
+
+```python
+def f():
+    x: int
+    print(x)  # dynamic error: local variable x referenced before assignment
+    x = 42
+```
+
+### Cast expressions
+
+A `cast` expression informs the type checker of an expression's type, but at
+evaluation time, returns the expression's value unchanged.
+
+Syntactically, a `cast` expression looks like a call expression with 2 arguments
+\- a type expression and an ordinary argument expression:
+
+```
+CastExpr = 'cast' '(' TypeExpr ',' [','] Argument [','] ')'
+```
+
+Example:
+
+```python
+def f(l: list[int], y: int | None):
+    if x:
+        l.append(cast(int, c))
+```
+
+### Isinstance expressions
+
+An `isinstance` expression evaluates to `True` if a value's data type matches a
+given type annotation, and to `False` otherwise.
+
+Syntactically, an `isinstance` expression looks like a call expression with 2
+arguments - an ordinary argument expression and a type expression (the opposite
+order from `cast` expressions):
+
+```
+IsInstanceExpr = 'isinstance' '(' Argument ',' [','] TypeExpr [','] ')'
+```
+
+For efficiency reasons, it is a static error to use `isinstance` with collection
+type annotations that specify the types of elements, keys, or values:
+
+```python
+isinstance(x, list)               # ok
+isinstance(x, list | dict | str)  # ok
+isinstance(x, list[int])          # static error: isinstance cannot be used with 'list[int]'
+```
 
 ## Module execution
 
@@ -4720,6 +4942,8 @@ Letters are converted to uppercase at the start of words, lowercase elsewhere.
 
 ## Grammar reference
 
+In Wirth syntax notation:
+
 ```text
 File = {Statement | newline} eof .
 
@@ -4750,16 +4974,25 @@ SmallStmt = ReturnStmt
           | AssignStmt
           | ExprStmt
           | LoadStmt
+          | TypeAliasStmt
+          | VarStmt
           .
 
 ReturnStmt   = 'return' [Expressions] .
 BreakStmt    = 'break' .
 ContinueStmt = 'continue' .
 PassStmt     = 'pass' .
-AssignStmt   = Expressions ('=' | '+=' | '-=' | '*=' | '/=' | '//=' | '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=') Expressions .
+AssignStmt   = Expressions ('=' | '+=' | '-=' | '*=' | '/=' | '//=' | '%=' | '&=' | '|=' | '^=' | '<<=' | '>>=') Expressions
+             | identifier ':' TypeExpr '=' Expressions
+             .
 ExprStmt     = Expressions .
 
 LoadStmt = 'load' '(' string {',' [identifier '='] string} [','] ')' .
+
+TypeAliasStmt = 'type' identifier {'[' TypeParams [','] ']'} '=' TypeExpr.
+# NOTE: allowed only at the top level of a file.
+
+VarStmt = identifier ':' TypeExpr.
 
 Expression = IfExpr | PrimaryExpr | UnaryExpr | BinaryExpr | LambdaExpr .
 
@@ -4769,6 +5002,8 @@ PrimaryExpr = Operand
             | PrimaryExpr DotSuffix
             | PrimaryExpr CallSuffix
             | PrimaryExpr SubscriptSuffix
+            | CastExpr
+            | IsInstanceExpr
             .
 
 Operand = identifier
@@ -4822,6 +5057,41 @@ Expressions = Expression {',' Expression} .
 # NOTE: trailing comma permitted only when within [...] or (...).
 
 LoopVariables = PrimaryExpr {',' PrimaryExpr} .
+
+TypeExpr = TypeAtom
+         | TypeAtom '|' TypeExpr
+         .
+
+TypeAtom = TypeName
+         | TypeApplication
+         .
+
+TypeName = identifier
+         | TypeName DotSuffix
+         .
+
+TypeApplication = TypeName '[' [TypeArgument [',']] ']'.
+
+TypeArguments = [TypeArgument [',']].
+
+TypeArgument = TypeExpr
+             | TypeList
+             | TypeDict
+             | string
+             | int
+             | '(' ')'
+             | '...'
+             .
+
+TypeList = '[' [TypeExpr [',']] ']' .
+
+TypeDict = '{' [TypeDictEntry [',']] '}' .
+
+TypeDictEntry = string ':' TypeExpr .
+
+CastExpr = 'cast' '(' TypeExpr ',' [','] Argument [','] ')'
+
+IsInstanceExpr = 'isinstance' '(' Argument ',' [','] TypeExpr [','] ')'
 ```
 
 Tokens:

--- a/spec.md
+++ b/spec.md
@@ -3228,16 +3228,18 @@ TypeName = identifier
          | TypeName DotSuffix
          .
 
-TypeApplication = TypeName '[' [TypeArgument [',']] ']'.
+TypeApplication = TypeName '[' TypeArguments ']'.
 ```
 
 The *type arguments* of a type application is a non-empty sequence of type
 expressions, lists of type expressions, string-keyed dicts with type expression
 values, strings or integer literals, empty tuples, and/or the special *ellipsis*
-token(s) `...`; a trailing comma is allowed:
+token(s) `...`. For compatibility with subscript expression syntax, type
+arguments _cannot_ have a trailing comma.
 
 ```
-TypeArguments = [TypeArgument [',']]
+TypeArguments = TypeArgument
+              | TypeArgument ',' TypeArguments
               .
 
 TypeArgument = TypeExpr
@@ -5070,9 +5072,11 @@ TypeName = identifier
          | TypeName DotSuffix
          .
 
-TypeApplication = TypeName '[' [TypeArgument [',']] ']'.
+TypeApplication = TypeName '[' TypeArguments ']'.
 
-TypeArguments = [TypeArgument [',']].
+TypeArguments = TypeArgument
+              | TypeArgument ',' TypeArguments
+              .
 
 TypeArgument = TypeExpr
              | TypeList


### PR DESCRIPTION
This is basically the syntax experimentally supported by Bazel at HEAD but with support for namespaced type names as used by Buck2.

It is also a subset of the Python3 type annotation syntax. (We want Starlark to be syntactically a subset of Python!)

This PR does not specify the semantics of type checking - it only specifies eval-time behavior of the new syntactic constructs.

If we at least agree on the syntax, it can be used by common tooling like buildifier et al.

Miscellaneous notes:

* `type` is not a keyword because we want to allow it to be used for variable names
* but `cast` and `isinstance` do have to be keywords because they take a type expression as argument, and type expressions *aren't* subsets of ordinary expression syntax (~~type applications allow trailing commas before the closing `]`, and~~ type syntax is allowed to use ellipsis `...` literals).

Working towards #106.

@brandjon @adonovan FYI